### PR TITLE
Add random demo and expose reward info

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ This repository implements a reinforcement learning setup that interacts with an
    ```bash
    python main.py
    ```
+3. Run a quick random-action demo to inspect rewards:
+   ```bash
+   python examples/random_agent.py
+   ```
 
 Dependencies include `torch`, `gymnasium`, `numpy`, `transformers`, `pymem`, `psutil`, `pynput` and `opencv-python`.

--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -89,7 +89,11 @@ class SocketAppEnv(gym.Env):
 
         terminated = False
         truncated = self.step_count >= self.max_steps
-        return obs_np.astype(np.float32), reward, terminated, truncated, {}
+        info = {
+            "extrinsic": float(extrinsic),
+            "intrinsic": float(intrinsic),
+        }
+        return obs_np.astype(np.float32), reward, terminated, truncated, info
 
     def _send_action(self, action_idx):
         msg = str(action_idx).encode()

--- a/examples/random_agent.py
+++ b/examples/random_agent.py
@@ -1,0 +1,20 @@
+from envs.socket_env import SocketAppEnv
+
+def main():
+    env = SocketAppEnv(max_steps=10, device="cpu", start_servers=True, combined_server=True)
+    obs, _ = env.reset()
+    print(f"Initial obs shape: {obs.shape}")
+    for step in range(10):
+        action = env.action_space.sample()
+        obs, reward, terminated, truncated, info = env.step(action)
+        print(
+            f"[Step {step:02d}] action={action} extrinsic={info['extrinsic']:.3f} "
+            f"intrinsic={info['intrinsic']:.3f} total={reward:.3f}"
+        )
+        if terminated or truncated:
+            break
+    env.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- include intrinsic and extrinsic rewards in `SocketAppEnv.step`
- add a `random_agent.py` example that prints reward components
- mention the demo script in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d637a45d8832a99dca59466179de5