### PR TITLE
Fix rollout buffer state dimensions

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,8 @@ def main() -> None:
         writer.add_scalar("Reward/Total", total_r, step_count)
 
         value = critic(emb_seq, act_onehot).squeeze()
-        buffer.add(emb_seq[0].cpu(), act_onehot.cpu(), total_r, value.cpu(), logp.cpu())
+        state_tensor = torch.from_numpy(emb_np).float()
+        buffer.add(state_tensor, act_onehot.cpu(), total_r, value.cpu(), logp.cpu())
 
         step_count += 1
         writer.add_scalar("Reward/Total", total_r, step_count)


### PR DESCRIPTION
## Summary
- fix state tensor shape when storing trajectories in RolloutBufferNoDone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e1e63bfe8832aaba8aee37b40e89e