### PR TITLE
Use SocketAppEnv and add buffer test

### DIFF
--- a/tests/test_rollout_buffer.py
+++ b/tests/test_rollout_buffer.py
@@ -1,0 +1,20 @@
+import torch
+from utils.rollout import RolloutBufferNoDone
+
+
+def test_get_latest_state_seq_basic():
+    buf = RolloutBufferNoDone(size=10, state_dim=2, action_dim=1, device="cpu")
+    # Add a few states
+    for i in range(3):
+        s = torch.tensor([float(i), float(i)])
+        a = torch.zeros(1)
+        buf.add(s, a, 0.0, 0.0, 0.0)
+
+    new_state = torch.tensor([99.0, 99.0])
+    seq = buf.get_latest_state_seq(new_state)
+
+    assert seq.shape == (1, buf.seq_len, 2)
+    # First entries should be [new_state, last_state, second_last_state]
+    assert torch.allclose(seq[0, 0], new_state)
+    assert torch.allclose(seq[0, 1], torch.tensor([2.0, 2.0]))
+    assert torch.allclose(seq[0, 2], torch.tensor([1.0, 1.0]))


### PR DESCRIPTION
## Summary
- refactor `main.py` to rely on `SocketAppEnv`
- drop `LogStencilMemory` and use buffer's `get_latest_state_seq`
- add a small test that demonstrates how `RolloutBufferNoDone` forms a sequence

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685e21ee5630832aada8a31a4e9380f5