### PR TITLE
Add video frame extraction and embedding cache utilities

### DIFF
--- a/lab/README.md
+++ b/lab/README.md
@@ -20,3 +20,25 @@ python train_tmdn.py --data-dir /path/to/videos --epochs 5 --batch-size 4
 ```
 
 The script will save the trained model weights to `tmdn_model.pt`.
+
+## Image Pipeline
+
+Three helper scripts are provided for workflows that operate on directories of videos and frames:
+
+1. `scripts/mp4_to_png.py` – converts every `.mp4` in a directory into a folder of PNG frames using ffmpeg. Frames are skipped according to a desired FPS without interpolation.
+2. `scripts/cache_embeddings.py` – encodes the extracted PNG frames with DINOv2 small and stores the embeddings in an H5 file.
+3. `scripts/train_from_h5.py` – trains the TMDN model using the cached embeddings.
+
+The default dataset settings use a history of 30 frame embeddings and predict one frame 30 frames later (i.e. 1 second at 30 fps).
+
+Example usage:
+```bash
+# 1. Extract frames
+python scripts/mp4_to_png.py --video-dir /path/to/videos --out-dir frames --fps 1
+
+# 2. Cache embeddings
+python scripts/cache_embeddings.py --image-dir frames --output data.h5
+
+# 3. Train model
+python scripts/train_from_h5.py --h5 data.h5 --epochs 5 --batch-size 4
+```

--- a/lab/scripts/cache_embeddings.py
+++ b/lab/scripts/cache_embeddings.py
@@ -1,0 +1,69 @@
+import argparse
+from pathlib import Path
+import h5py
+import torch
+from torchvision import transforms
+from PIL import Image
+
+try:
+    from dinov2.models import vit_small, load_pretrained_weights
+except Exception:  # pragma: no cover - dinov2 may not be installed in tests
+    vit_small = None
+
+
+def load_model(device: str):
+    if vit_small is None:
+        raise RuntimeError("dinov2 is required for embedding extraction")
+    model = vit_small()
+    load_pretrained_weights(model, model_name="dinov2_vits14")
+    model.to(device)
+    model.eval()
+    return model
+
+
+def transform_image():
+    return transforms.Compose([
+        transforms.Resize((224, 224)),
+        transforms.ToTensor(),
+        transforms.Normalize(mean=0.5, std=0.5),
+    ])
+
+
+def encode_image(img_path: Path, model, transform, device: str):
+    img = Image.open(img_path).convert("RGB")
+    tensor = transform(img).unsqueeze(0).to(device)
+    with torch.no_grad():
+        emb = model(tensor).squeeze(0).cpu()
+    return emb
+
+
+def process_sequence(seq_dir: Path, model, transform, device: str):
+    images = sorted(seq_dir.glob("*.png"))
+    embeddings = []
+    for img in images:
+        embeddings.append(encode_image(img, model, transform, device))
+    if embeddings:
+        return torch.stack(embeddings)
+    return torch.empty(0, 384)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Cache DINOv2 embeddings to H5")
+    p.add_argument("--image-dir", type=str, required=True, help="Root directory with frame folders")
+    p.add_argument("--output", type=str, required=True, help="Output H5 file")
+    p.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    args = p.parse_args()
+
+    transform = transform_image()
+    model = load_model(args.device)
+
+    with h5py.File(args.output, "w") as h5f:
+        for seq_dir in sorted(Path(args.image_dir).iterdir()):
+            if not seq_dir.is_dir():
+                continue
+            emb = process_sequence(seq_dir, model, transform, args.device)
+            h5f.create_dataset(seq_dir.name, data=emb.numpy())
+
+
+if __name__ == "__main__":
+    main()

--- a/lab/scripts/mp4_to_png.py
+++ b/lab/scripts/mp4_to_png.py
@@ -1,0 +1,36 @@
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def convert(video_path: Path, out_dir: Path, fps: int) -> None:
+    """Convert a single mp4 file to a PNG frame sequence."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg",
+        "-i",
+        str(video_path),
+        "-vf",
+        f"fps={fps}",
+        "-vsync",
+        "0",
+        str(out_dir / "%06d.png"),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Convert MP4 videos to PNG sequences")
+    p.add_argument("--video-dir", type=str, required=True, help="Directory with mp4 files")
+    p.add_argument("--out-dir", type=str, required=True, help="Output directory for frames")
+    p.add_argument("--fps", type=int, default=1, help="Frames per second to extract")
+    args = p.parse_args()
+
+    video_dir = Path(args.video_dir)
+    out_root = Path(args.out_dir)
+    for video_file in sorted(video_dir.glob("*.mp4")):
+        convert(video_file, out_root / video_file.stem, args.fps)
+
+
+if __name__ == "__main__":
+    main()

--- a/lab/scripts/train_from_h5.py
+++ b/lab/scripts/train_from_h5.py
@@ -1,0 +1,44 @@
+import argparse
+from torch.utils.data import DataLoader
+import torch
+from pathlib import Path
+
+from tmdn import create_tmdn_model, train_step
+from dataset import EmbeddingH5Dataset
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Train TMDN using cached embeddings")
+    p.add_argument("--h5", type=str, required=True, help="H5 file with embeddings")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch-size", type=int, default=2)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dataset = EmbeddingH5Dataset(args.h5)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True, num_workers=0)
+
+    model = create_tmdn_model().to(args.device)
+    optim = torch.optim.Adam(model.parameters(), lr=args.lr)
+
+    for epoch in range(args.epochs):
+        for seq, target in loader:
+            seq = seq.to(args.device)
+            target = target.to(args.device)
+            loss, _ = train_step(model, seq, target)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+        print(f"Epoch {epoch+1}, loss {loss.item():.4f}")
+
+    save_path = Path("tmdn_model.pt")
+    torch.save(model.state_dict(), save_path)
+    print(f"Model saved to {save_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add scripts for extracting mp4 frames to png using ffmpeg
- add script to cache DINOv2 frame embeddings into an H5 dataset
- add training script that consumes cached embeddings
- extend dataset module with `EmbeddingH5Dataset`
- document the image pipeline in the lab README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685ea3ba9cb4832a94d8246046c6f1d8