### PR TITLE
Fix path for TMDN training script

### DIFF
--- a/lab/scripts/train_from_h5.py
+++ b/lab/scripts/train_from_h5.py
@@ -2,6 +2,10 @@ import argparse
 from torch.utils.data import DataLoader
 import torch
 from pathlib import Path
+import sys
+
+# Ensure imports work when the script is executed from within this directory
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from tmdn import create_tmdn_model, train_step
 from dataset import EmbeddingH5Dataset


### PR DESCRIPTION
## Summary
- ensure `lab/scripts/train_from_h5.py` works when executed from within the `scripts` folder

## Testing
- `python -m py_compile lab/scripts/train_from_h5.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685f92c7ee14832a8e82137d0919befb