### PR TITLE
Fix denoiser input size in TMDN

### DIFF
--- a/lab/tmdn.py
+++ b/lab/tmdn.py
@@ -175,7 +175,7 @@ class TemporalManifoldDiffusionNetwork(nn.Module):
         ])
         self.noise_scheduler = nn.Parameter(torch.linspace(0.1, 0.9, diffusion_steps))
         self.denoise_net = nn.Sequential(
-            nn.Linear(hidden_dim + 1, hidden_dim),
+            nn.Linear(hidden_dim * 2, hidden_dim),
             nn.SiLU(),
             nn.Linear(hidden_dim, hidden_dim),
             nn.SiLU(),


### PR DESCRIPTION
## Summary
- correct layer size for `denoise_net` in `tmdn.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685f956d7480832a9fe3bdc025f7c6da