### PR TITLE
Improve H5 training logging

### DIFF
--- a/lab/scripts/train_from_h5.py
+++ b/lab/scripts/train_from_h5.py
@@ -1,7 +1,9 @@
 import argparse
 from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
 import torch
 from pathlib import Path
+from tqdm import tqdm
 import sys
 
 # Ensure imports work when the script is executed from within this directory
@@ -18,6 +20,7 @@ def parse_args():
     p.add_argument("--batch-size", type=int, default=2)
     p.add_argument("--lr", type=float, default=1e-4)
     p.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    p.add_argument("--log-dir", type=str, default="runs/tmdn_h5", help="TensorBoard log directory")
     return p.parse_args()
 
 
@@ -28,16 +31,29 @@ def main() -> None:
 
     model = create_tmdn_model().to(args.device)
     optim = torch.optim.Adam(model.parameters(), lr=args.lr)
+    writer = SummaryWriter(log_dir=args.log_dir)
+    global_step = 0
 
     for epoch in range(args.epochs):
-        for seq, target in loader:
+        epoch_loss = 0.0
+        pbar = tqdm(loader, desc=f"Epoch {epoch+1}/{args.epochs}")
+        for seq, target in pbar:
             seq = seq.to(args.device)
             target = target.to(args.device)
             loss, _ = train_step(model, seq, target)
             optim.zero_grad()
             loss.backward()
             optim.step()
-        print(f"Epoch {epoch+1}, loss {loss.item():.4f}")
+
+            writer.add_scalar("loss/step", loss.item(), global_step)
+            epoch_loss += loss.item() * seq.size(0)
+            global_step += 1
+            pbar.set_postfix(loss=f"{loss.item():.4f}")
+        avg_loss = epoch_loss / len(loader.dataset)
+        writer.add_scalar("loss/epoch", avg_loss, epoch)
+        print(f"Epoch {epoch+1}, avg loss {avg_loss:.4f}")
+
+    writer.close()
 
     save_path = Path("tmdn_model.pt")
     torch.save(model.state_dict(), save_path)


### PR DESCRIPTION
## Summary
- log step/epoch loss to TensorBoard
- show training progress with tqdm

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685f9883561c832aa74eed675c773df8