### PR TITLE
Prevent NaNs in TMDN training

### DIFF
--- a/lab/dataset.py
+++ b/lab/dataset.py
@@ -90,5 +90,5 @@ class EmbeddingH5Dataset(Dataset):
         with h5py.File(self.h5_path, "r") as f:
             data = f[key][start:start + self.sequence_length]
             target = f[key][start + self.sequence_length + self.frame_gap - 1]
-        return torch.tensor(data), torch.tensor(target)
+        return torch.tensor(data, dtype=torch.float32), torch.tensor(target, dtype=torch.float32)
 

--- a/lab/tmdn.py
+++ b/lab/tmdn.py
@@ -34,7 +34,10 @@ class GeometricAttention(nn.Module):
         # Poincar\xe9 ball distance
         num = 2 * torch.norm(x - y, dim=-1, keepdim=True) ** 2
         denom = (1 - c * x_norm) * (1 - c * y_norm)
-        return torch.acosh(1 + c * num / denom) / torch.sqrt(c)
+        denom = torch.clamp(denom, min=1e-5)
+        arg = 1 + c * num / denom
+        arg = torch.clamp(arg, min=1.00001)
+        return torch.acosh(arg) / torch.sqrt(c)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         B, T, D = x.shape


### PR DESCRIPTION
## Summary
- clamp values in `hyperbolic_distance` to avoid invalid `acosh` arguments
- ensure `EmbeddingH5Dataset` tensors are float32

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685f9d18acf4832a8f9069e16ecb73eb