### PR TITLE
Fix runaway autograd graph in PPO loop

### DIFF
--- a/main.py
+++ b/main.py
@@ -66,8 +66,9 @@ def main() -> None:
         act_onehot = act_onehot.unsqueeze(0)
         writer.add_scalar("Reward/Total", reward, step_count)
 
-        value = critic(emb_seq, act_onehot.to(DEVICE)).squeeze()
-        buffer.add(state_tensor, act_onehot.cpu(), reward, value.cpu(), logp.cpu())
+        value = critic(emb_seq, act_onehot.to(DEVICE)).squeeze().detach()
+        logp_detached = logp.detach()
+        buffer.add(state_tensor, act_onehot.cpu(), reward, value.cpu(), logp_detached.cpu())
         if terminated or truncated:
             obs, _ = env.reset()
 


### PR DESCRIPTION
## Summary
- detach log probabilities and value predictions before saving to the rollout buffer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686241bbe488832a89994e80d3228f06