### PR TITLE
Fix socket reuse error on world model server

### DIFF
--- a/servers/world_model_server.py
+++ b/servers/world_model_server.py
@@ -34,6 +34,8 @@ def start_udp_world_model_server(model_path: str = DEFAULT_MODEL_PATH, host: str
     model.eval()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    # Allow quick rebinding in case a previous instance recently exited
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind((host, port))
     print(f"[WorldModelServer] Listening on udp://{host}:{port}")
 


### PR DESCRIPTION
## Summary
- allow the UDP socket in `world_model_server.py` to reuse an address

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6862458d45ec832a9ff3084083cfb70f