### PR TITLE
Allow variable prediction horizon in lab RNN training

### DIFF
--- a/lab/README.md
+++ b/lab/README.md
@@ -30,7 +30,7 @@ Three helper scripts are provided for workflows that operate on directories of v
 
 3. `scripts/train_from_h5.py` – trains the TMDN model using the cached embeddings.
 
-The default dataset settings use a history of 30 frame embeddings and predict one frame 30 frames later (i.e. 1 second at 30 fps).
+The default dataset settings use a history of 30 frame embeddings and predict the next frame by default. Pass ``--frame-gap`` to train the models to predict further into the future.
 
 Example usage:
 ```bash
@@ -52,6 +52,8 @@ A second experiment explores a simpler recurrent approach for next-frame predict
 Training from cached embeddings can be done with:
 ```bash
 python scripts/train_rnn.py --h5 data.h5 --model lstm --epochs 5 --batch-size 4
+# predict five steps ahead
+python scripts/train_rnn.py --h5 data.h5 --frame-gap 5 --epochs 5
 ```
 
 A larger GRU variant may be trained by increasing the hidden dimension:

--- a/lab/dataset.py
+++ b/lab/dataset.py
@@ -65,7 +65,7 @@ class VideoDataset(Dataset):
         return emb_seq[:-1], emb_seq[-1]
 
 class EmbeddingH5Dataset(Dataset):
-    def __init__(self, h5_path: str, sequence_length: int = 30, frame_gap: int = 30):
+    def __init__(self, h5_path: str, sequence_length: int = 30, frame_gap: int = 1):
         self.h5_path = h5_path
         self.sequence_length = sequence_length
         self.frame_gap = frame_gap


### PR DESCRIPTION
## Summary
- default `frame_gap` is now 1 instead of 30 in `EmbeddingH5Dataset`
- add `--frame-gap` and `--checkpoint` options to training scripts
- load checkpoints when provided
- update lab README for new defaults and example for multi‑step prediction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68625008df28832a9c53680a70af5ec7