### PR TITLE
Add training metrics logger

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -132,6 +132,7 @@ class SocketAppEnv(gym.Env):
         if self._logger is not None:
             self._logger.log_scalar("Reward/Extrinsic", extrinsic, self.step_count)
             self._logger.log_scalar("Reward/Intrinsic", intrinsic, self.step_count)
+            self._logger.log_scalar("Reward/ModelBonus", model_bonus, self.step_count)
             self._logger.log_scalar("Reward/Total", reward, self.step_count)
 
         terminated = False

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,7 +1,32 @@
+from typing import Any, Dict, Iterable
+
+import numpy as np
 from torch.utils.tensorboard import SummaryWriter
 
 _writer = SummaryWriter()
 
-def log_scalar(tag: str, value: float, step: int):
+
+def log_scalar(tag: str, value: float, step: int) -> None:
     """Log a scalar value to TensorBoard."""
-    _writer.add_scalar(tag, value, step)
+    _writer.add_scalar(tag, float(value), step)
+
+
+def log_histogram(tag: str, values: Iterable[float], step: int) -> None:
+    """Log a histogram of values to TensorBoard."""
+    arr = np.asarray(list(values), dtype=np.float32)
+    _writer.add_histogram(tag, arr, step)
+
+
+def log_dict(metrics: Dict[str, Any], step: int) -> None:
+    """Log multiple scalar metrics from a dictionary."""
+    for k, v in metrics.items():
+        try:
+            val = float(v)
+        except Exception:
+            continue
+        _writer.add_scalar(k, val, step)
+
+
+def get_writer() -> SummaryWriter:
+    """Expose the underlying ``SummaryWriter`` for advanced usage."""
+    return _writer


### PR DESCRIPTION
## Summary
- expand logger to support histograms and multi-metric dicts
- log extrinsic, intrinsic and model bonus rewards in `SocketAppEnv`
- return KL divergence and losses from PPO update
- track metrics and action distributions in the main training loop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68626352168c832aa6b8ea949b8fe862