### PR TITLE
Add memory caching for H5 dataset and MLP world model

### DIFF
--- a/lab/README.md
+++ b/lab/README.md
@@ -4,7 +4,8 @@ This directory contains an implementation of the **Temporal Manifold Diffusion N
 
 Files:
 - `tmdn.py` – the model architecture and helper functions.
-- `dataset.py` – simple dataset class that loads video files and generates sequences of DINOv2 embeddings.
+- `dataset.py` – dataset helpers. `EmbeddingH5Dataset` now caches the entire H5
+  file in memory on first use for fast multi-worker access.
 - `train_tmdn.py` – example training script for running TMDN on a directory of videos.
 
 ## Usage
@@ -62,3 +63,16 @@ python scripts/train_rnn.py --h5 data.h5 --model gru --hidden-dim 1024
 ```
 
 In our tests the trained TMDN outperformed the GRU baseline in prediction accuracy even when the GRU used the bigger hidden size.
+
+## Experiment 3: MLP World Model
+
+The script `scripts/train_mlp.py` implements a simple feed-forward baseline that
+predicts the next embedding from a single state. Use the cached embedding H5
+file and train the model with:
+
+```bash
+python scripts/train_mlp.py --h5 data.h5 --epochs 5
+```
+
+This baseline is useful for quick experiments when only one frame of history is
+available.

--- a/lab/mlp_world_model.py
+++ b/lab/mlp_world_model.py
@@ -1,0 +1,27 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class MLPWorldModel(nn.Module):
+    """Predicts the next embedding from the current embedding."""
+
+    def __init__(self, input_dim: int = 384, hidden_dim: int = 512, num_layers: int = 2) -> None:
+        super().__init__()
+        layers = []
+        dim = input_dim
+        for _ in range(max(1, num_layers - 1)):
+            layers.append(nn.Linear(dim, hidden_dim))
+            layers.append(nn.ReLU())
+            dim = hidden_dim
+        layers.append(nn.Linear(dim, input_dim))
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+def mlp_loss(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    """Combination of MSE and cosine similarity loss used for prediction."""
+    mse = F.mse_loss(prediction, target)
+    cosine = 1 - F.cosine_similarity(prediction, target).mean()
+    return mse + cosine

--- a/lab/scripts/train_mlp.py
+++ b/lab/scripts/train_mlp.py
@@ -1,0 +1,74 @@
+import argparse
+from pathlib import Path
+import sys
+
+import torch
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from dataset import EmbeddingH5Dataset
+from mlp_world_model import MLPWorldModel, mlp_loss
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Train MLP world model on embeddings")
+    p.add_argument("--h5", type=str, required=True, help="H5 file with embeddings")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--lr", type=float, default=1e-4)
+    p.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
+    p.add_argument("--hidden-dim", type=int, default=512)
+    p.add_argument("--layers", type=int, default=2)
+    p.add_argument("--log-dir", type=str, default="runs/mlp_world_model")
+    p.add_argument("--checkpoint", type=str, help="Optional checkpoint to resume from")
+    p.add_argument("--no-bf16", dest="use_bf16", action="store_false", help="Disable bfloat16 mixed precision")
+    p.set_defaults(use_bf16=True)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dataset = EmbeddingH5Dataset(args.h5, sequence_length=1)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True, num_workers=0)
+
+    model = MLPWorldModel(hidden_dim=args.hidden_dim, num_layers=args.layers).to(args.device)
+    if args.checkpoint:
+        try:
+            state = torch.load(args.checkpoint, map_location=args.device)
+            model.load_state_dict(state)
+            print(f"Loaded checkpoint {args.checkpoint}")
+        except Exception as e:
+            print(f"Failed to load {args.checkpoint}: {e}")
+    optim = torch.optim.Adam(model.parameters(), lr=args.lr)
+    writer = SummaryWriter(log_dir=args.log_dir)
+
+    global_step = 0
+    for epoch in range(args.epochs):
+        epoch_loss = 0.0
+        for seq, target in loader:
+            seq = seq.squeeze(1).to(args.device)
+            target = target.to(args.device)
+            with torch.amp.autocast(args.device, dtype=torch.bfloat16, enabled=args.use_bf16):
+                pred = model(seq)
+                loss = mlp_loss(pred, target)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+
+            writer.add_scalar("loss/step", loss.item(), global_step)
+            epoch_loss += loss.item() * seq.size(0)
+            global_step += 1
+        avg = epoch_loss / len(loader.dataset)
+        writer.add_scalar("loss/epoch", avg, epoch)
+        print(f"Epoch {epoch+1}, avg loss {avg:.4f}")
+
+    writer.close()
+    save_path = Path("mlp_world_model.pt")
+    torch.save(model.state_dict(), save_path)
+    print(f"Model saved to {save_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- cache entire H5 file in `EmbeddingH5Dataset` for fast access
- document dataset caching and add instructions for new MLP experiment
- implement a simple `MLPWorldModel` and training script

## Testing
- `python -m py_compile lab/dataset.py lab/mlp_world_model.py lab/scripts/train_mlp.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68639e03727c832ab5745077761f0965