### PR TITLE
Log individual losses to TensorBoard

### DIFF
--- a/lab/mlp_world_model.py
+++ b/lab/mlp_world_model.py
@@ -20,8 +20,11 @@ class MLPWorldModel(nn.Module):
         return self.net(x)
 
 
-def mlp_loss(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
-    """Combination of MSE and cosine similarity loss used for prediction."""
+def mlp_loss(
+    prediction: torch.Tensor, target: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return MSE, cosine and combined losses for the prediction."""
     mse = F.mse_loss(prediction, target)
     cosine = 1 - F.cosine_similarity(prediction, target).mean()
-    return mse + cosine
+    total = mse + cosine
+    return mse, cosine, total

--- a/lab/rnn_baseline.py
+++ b/lab/rnn_baseline.py
@@ -18,7 +18,11 @@ class RNNPredictor(nn.Module):
         last = out[:, -1]
         return self.fc(last)
 
-def rnn_loss(prediction: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+def rnn_loss(
+    prediction: torch.Tensor, target: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return MSE, cosine and combined losses for the prediction."""
     mse = F.mse_loss(prediction, target)
     cosine = 1 - F.cosine_similarity(prediction, target).mean()
-    return mse + cosine
+    total = mse + cosine
+    return mse, cosine, total

--- a/lab/scripts/train_mlp.py
+++ b/lab/scripts/train_mlp.py
@@ -47,21 +47,32 @@ def main() -> None:
     global_step = 0
     for epoch in range(args.epochs):
         epoch_loss = 0.0
+        epoch_mse = 0.0
+        epoch_cos = 0.0
         for seq, target in loader:
             seq = seq.squeeze(1).to(args.device)
             target = target.to(args.device)
             with torch.amp.autocast(args.device, dtype=torch.bfloat16, enabled=args.use_bf16):
                 pred = model(seq)
-                loss = mlp_loss(pred, target)
+                mse_loss, cos_loss, loss = mlp_loss(pred, target)
             optim.zero_grad()
             loss.backward()
             optim.step()
 
+            writer.add_scalar("loss/mse_step", mse_loss.item(), global_step)
+            writer.add_scalar("loss/cosine_step", cos_loss.item(), global_step)
             writer.add_scalar("loss/step", loss.item(), global_step)
             epoch_loss += loss.item() * seq.size(0)
+            epoch_mse += mse_loss.item() * seq.size(0)
+            epoch_cos += cos_loss.item() * seq.size(0)
             global_step += 1
-        avg = epoch_loss / len(loader.dataset)
+        dataset_len = len(loader.dataset)
+        avg = epoch_loss / dataset_len
+        avg_mse = epoch_mse / dataset_len
+        avg_cos = epoch_cos / dataset_len
         writer.add_scalar("loss/epoch", avg, epoch)
+        writer.add_scalar("loss/mse_epoch", avg_mse, epoch)
+        writer.add_scalar("loss/cosine_epoch", avg_cos, epoch)
         print(f"Epoch {epoch+1}, avg loss {avg:.4f}")
 
     writer.close()


### PR DESCRIPTION
## Summary
- expose mse and cosine losses in rnn_loss, mlp_loss, and tmdn_loss
- return loss components from train_step
- log mse, cosine, and total loss values in training scripts

## Testing
- `python3 -m py_compile lab/scripts/train_rnn.py lab/scripts/train_mlp.py lab/scripts/train_from_h5.py lab/rnn_baseline.py lab/mlp_world_model.py lab/tmdn.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6863b43887d8832aa97266f726828531