### PR TITLE
Use cosine distance in SocketAppEnv

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -10,7 +10,7 @@ from servers.constants import ARROW_DELAY, WAIT_DELAY, ARROW_IDX, WAIT_IDX
 
 from utils.observations import LocalObs
 from utils.intrinsic import E3BIntrinsicReward
-from utils.wasserstein import wasserstein_distance
+from utils.cosine import cosine_distance
 
 class SocketAppEnv(gym.Env):
     metadata = {"render_modes": []}
@@ -124,7 +124,7 @@ class SocketAppEnv(gym.Env):
                 # test here for timeout error
                 pred = np.frombuffer(pred_bytes, dtype=np.float32)
                 if pred.size == self.state_dim:
-                    dist = wasserstein_distance(pred, obs_np)
+                    dist = cosine_distance(pred, obs_np)
                     model_bonus = -dist/10
             except socket.timeout:
                 model_bonus = 99.99

--- a/utils/cosine.py
+++ b/utils/cosine.py
@@ -1,0 +1,15 @@
+import numpy as np
+
+
+def cosine_distance(u: np.ndarray, v: np.ndarray) -> float:
+    """Return 1 - cosine similarity between two vectors."""
+    u = np.asarray(u, dtype=np.float32).ravel()
+    v = np.asarray(v, dtype=np.float32).ravel()
+    if u.size == 0 or v.size == 0:
+        return 0.0
+    norm_u = np.linalg.norm(u)
+    norm_v = np.linalg.norm(v)
+    if norm_u == 0.0 or norm_v == 0.0:
+        return 0.0
+    cos_sim = float(np.dot(u, v) / (norm_u * norm_v))
+    return 1.0 - cos_sim


### PR DESCRIPTION
## Summary
- use cosine distance instead of Wasserstein distance for world model bonus
- implement simple cosine distance helper

## Testing
- `pytest tests/test_socket_env.py::test_socket_env_basic -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6863c7068a60832a88721f3658ba1db7