### PR TITLE
Add automatic world model config

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -27,7 +27,11 @@ class SocketAppEnv(gym.Env):
                  start_servers=False,
                  enable_logging=False,
                  use_world_model=False,
-                 world_model_host="127.0.0.1", world_model_port=5007):
+                 world_model_host="127.0.0.1", world_model_port=5007,
+                 world_model_path=None,
+                 world_model_type="auto",
+                 world_model_interval=5,
+                 world_model_time=1.0):
 
         super().__init__()
         self.max_steps = max_steps
@@ -50,6 +54,17 @@ class SocketAppEnv(gym.Env):
         self.enable_logging = enable_logging
         self.use_world_model = use_world_model
         self.wm_addr = (world_model_host, world_model_port)
+        self.world_model_type = world_model_type
+        if world_model_path is None:
+            if world_model_type == "mlp":
+                world_model_path = "lab/scripts/mlp_world_model.pt"
+            elif world_model_type == "gru":
+                world_model_path = "lab/scripts/rnn_gru.pt"
+            else:
+                world_model_path = "lab/scripts/rnn_lstm.pt"
+        self.world_model_path = world_model_path
+        self.wm_interval_steps = int(max(1, world_model_interval))
+        self.wm_time_interval = float(world_model_time)
         self._server_processes = []
         self._logger = None
         self._last_action_time = perf_counter()
@@ -115,7 +130,8 @@ class SocketAppEnv(gym.Env):
         if (
             self.use_world_model and
             len(self.obs_history) == 30 and
-            perf_counter() - self._last_wm_time >= 1.0
+            self.step_count % self.wm_interval_steps == 0 and
+            perf_counter() - self._last_wm_time >= self.wm_time_interval
         ):
             context = np.stack(self.obs_history, axis=0).astype(np.float32)
             try:
@@ -201,6 +217,12 @@ class SocketAppEnv(gym.Env):
             self._server_processes.append(p)
 
         if self.use_world_model:
-            cmd = [sys.executable, '-m', 'servers.world_model_server']
+            cmd = [
+                sys.executable, '-m', 'servers.world_model_server',
+                '--model-path', self.world_model_path,
+                '--model-type', self.world_model_type,
+                '--host', self.wm_addr[0],
+                '--port', str(self.wm_addr[1])
+            ]
             p = subprocess.Popen(cmd)
             self._server_processes.append(p)

--- a/servers/world_model_server.py
+++ b/servers/world_model_server.py
@@ -2,35 +2,104 @@ import socket
 import numpy as np
 import torch
 from models.world_model import LSTMWorldModel
+from lab.rnn_baseline import RNNPredictor
+from lab.mlp_world_model import MLPWorldModel
 
 
 DEFAULT_MODEL_PATH = "lab/scripts/rnn_lstm.pt"
 
 
+def _infer_rnn_config(state: dict[str, torch.Tensor], gates: int) -> tuple[int, int]:
+    """Infer ``hidden_dim`` and ``num_layers`` from an RNN state dict."""
+    weight_keys = [k for k in state if k.endswith("weight_ih_l0")]
+    if not weight_keys:
+        return 512, 2
+    key = weight_keys[0]
+    hidden_dim = state[key].shape[0] // gates
+    layers = 0
+    while f"rnn.weight_ih_l{layers}" in state or f"lstm.weight_ih_l{layers}" in state:
+        layers += 1
+    return hidden_dim, max(1, layers)
+
+
+def _infer_mlp_config(state: dict[str, torch.Tensor], obs_dim: int) -> tuple[int, int]:
+    """Infer ``hidden_dim`` and ``num_layers`` from an MLP state dict."""
+    linears = [k for k in state if k.startswith("net") and k.endswith(".weight")]
+    linears.sort()
+    num_layers = len(linears)
+    if not linears:
+        return obs_dim, 1
+    first = state[linears[0]]
+    hidden_dim = first.shape[0]
+    return hidden_dim, max(1, num_layers)
+
+
+from typing import Optional
+
+
 def start_udp_world_model_server(model_path: str = DEFAULT_MODEL_PATH, host: str = '0.0.0.0',
                                  port: int = 5007, obs_dim: int = 384,
-                                 seq_len: int = 30, device: str = 'cuda'):
+                                 seq_len: int = 30, device: str = 'cuda',
+                                 model_type: Optional[str] = 'auto'):
     """Start a UDP server that predicts the next observation embedding."""
-    model = LSTMWorldModel(obs_dim=obs_dim).to(device)
+    state = None
     if model_path:
         try:
             state = torch.load(model_path, map_location=device)
-            try:
-                model.load_state_dict(state)
-            except RuntimeError:
-                # Older checkpoints may use ``lstm`` as the module name.
-                # Rename keys on-the-fly to match the current implementation.
-                renamed = {}
-                for k, v in state.items():
-                    if k.startswith("lstm."):
-                        renamed["rnn." + k[5:]] = v
-                    else:
-                        renamed[k] = v
-                model.load_state_dict(renamed)
-
-            print(f"[WorldModelServer] Loaded model from {model_path}")
         except Exception as e:
             print(f"[WorldModelServer] Failed to load {model_path}: {e}")
+            state = None
+
+    if model_type is None or model_type == 'auto':
+        if state is not None:
+            if any(k.startswith('net.') for k in state):
+                model_type = 'mlp'
+            else:
+                key = next((k for k in state if 'weight_ih_l0' in k), None)
+                if key and state[key].shape[0] % 4 == 0:
+                    model_type = 'lstm'
+                elif key and state[key].shape[0] % 3 == 0:
+                    model_type = 'gru'
+                else:
+                    model_type = 'lstm'
+        else:
+            model_type = 'lstm'
+    model_type = model_type.lower()
+
+    # Infer hidden dim and layer count when a checkpoint was loaded
+    hidden_dim = 512
+    num_layers = 2 if model_type == 'mlp' else 3
+    if state is not None:
+        if model_type == 'mlp':
+            hidden_dim, num_layers = _infer_mlp_config(state, obs_dim)
+        elif model_type == 'gru':
+            hidden_dim, num_layers = _infer_rnn_config(state, 3)
+        else:
+            hidden_dim, num_layers = _infer_rnn_config(state, 4)
+
+    if model_type == 'mlp':
+        model = MLPWorldModel(input_dim=obs_dim, hidden_dim=hidden_dim,
+                              num_layers=num_layers).to(device)
+    elif model_type == 'gru':
+        model = RNNPredictor(input_dim=obs_dim, hidden_dim=hidden_dim,
+                             num_layers=num_layers, rnn_type='GRU').to(device)
+    else:
+        model = LSTMWorldModel(obs_dim=obs_dim, hidden_dim=hidden_dim,
+                               num_layers=num_layers).to(device)
+
+    if state is not None:
+        try:
+            model.load_state_dict(state)
+            print(f"[WorldModelServer] Loaded model from {model_path}")
+        except RuntimeError:
+            renamed = {}
+            for k, v in state.items():
+                if k.startswith("lstm."):
+                    renamed["rnn." + k[5:]] = v
+                else:
+                    renamed[k] = v
+            model.load_state_dict(renamed)
+            print(f"[WorldModelServer] Loaded model from {model_path} (renamed)")
     model.eval()
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -78,6 +147,8 @@ if __name__ == '__main__':
     parser.add_argument('--obs-dim', type=int, default=384, help='Dimension of observation embeddings')
     parser.add_argument('--seq-len', type=int, default=30, help='Length of the observation sequence')
     parser.add_argument('--device', default='cuda', help='Torch device')
+    parser.add_argument('--model-type', default='auto', choices=['lstm', 'gru', 'mlp', 'auto'],
+                        help='Type of world model to load or "auto" to infer from the checkpoint')
     args = parser.parse_args()
 
     start_udp_world_model_server(
@@ -87,4 +158,5 @@ if __name__ == '__main__':
         obs_dim=args.obs_dim,
         seq_len=args.seq_len,
         device=args.device,
+        model_type=args.model_type,
     )


### PR DESCRIPTION
## Summary
- support automatic world model type, hidden dim, and layer count detection
- allow auto defaults for world model path in `SocketAppEnv`
- update world model server CLI for auto detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864df509314832abb656d71c902f6aa