### PR TITLE
Fix numpy write warning in world model server

### DIFF
--- a/servers/world_model_server.py
+++ b/servers/world_model_server.py
@@ -61,7 +61,7 @@ def start_udp_world_model_server(model_path: str = DEFAULT_MODEL_PATH, host: str
                 sock.sendto(b'PONG', addr)
                 continue
 
-            arr = np.frombuffer(data, dtype=np.float32)
+            arr = np.frombuffer(data, dtype=np.float32).copy()
             if arr.size != seq_len * obs_dim:
                 sock.sendto(b'ERR', addr)
                 continue


### PR DESCRIPTION
## Summary
- fix warning about numpy array not being writable in `servers/world_model_server.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686506148d04832a83a2fb23d0afeaaf