### PR TITLE
Add simple bandit env for PPO demos

### DIFF
--- a/envs/__init__.py
+++ b/envs/__init__.py
@@ -1,0 +1,4 @@
+from .socket_env import SocketAppEnv
+from .bandit_env import MultiArmedBanditEnv
+
+__all__ = ["SocketAppEnv", "MultiArmedBanditEnv"]

--- a/envs/bandit_env.py
+++ b/envs/bandit_env.py
@@ -1,0 +1,32 @@
+import gymnasium as gym
+import numpy as np
+
+class MultiArmedBanditEnv(gym.Env):
+    """Simple multi-armed bandit environment for quick PPO tests."""
+    metadata = {"render_modes": []}
+
+    def __init__(self, probs=None):
+        super().__init__()
+        if probs is None:
+            probs = [0.2, 0.5, 0.8]
+        self.probs = np.array(probs, dtype=np.float32)
+        self.n_actions = len(self.probs)
+        self.action_space = gym.spaces.Discrete(self.n_actions)
+        self.observation_space = gym.spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32)
+        self.state = np.zeros(1, dtype=np.float32)
+
+    def reset(self, seed=None, options=None):
+        self.state.fill(0.0)
+        return self.state.copy(), {}
+
+    def step(self, action):
+        p = self.probs[int(action)]
+        reward = 1.0 if np.random.random() < p else 0.0
+        self.state[0] = reward
+        return self.state.copy(), reward, False, False, {}
+
+    def render(self):
+        pass
+
+    def close(self):
+        pass

--- a/examples/bandit_train.py
+++ b/examples/bandit_train.py
@@ -1,0 +1,68 @@
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.distributions as td
+
+from envs.bandit_env import MultiArmedBanditEnv
+from models.ppo import ppo_update
+from utils.rollout import RolloutBufferNoDone, compute_gae
+
+
+def main():
+    env = MultiArmedBanditEnv([0.1, 0.9])
+    device = "cpu"
+    state_dim = env.observation_space.shape[0]
+    action_dim = env.action_space.n
+    buffer = RolloutBufferNoDone(32, state_dim, action_dim, device)
+
+    class Actor(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(state_dim, action_dim)
+
+        def forward(self, seq):
+            x = seq[:, 0]
+            return self.fc(x)
+
+    class Critic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(state_dim + action_dim, 1)
+
+        def forward(self, seq, act):
+            x = torch.cat([seq[:, 0], act], dim=-1)
+            return self.fc(x).squeeze(-1)
+
+    actor = Actor().to(device)
+    critic = Critic().to(device)
+    opt_actor = optim.Adam(actor.parameters(), lr=0.01)
+    opt_critic = optim.Adam(critic.parameters(), lr=0.01)
+
+    obs, _ = env.reset()
+    for step in range(200):
+        s = torch.tensor(obs, dtype=torch.float32)
+        seq = buffer.get_latest_state_seq(s)
+        logits = actor(seq)
+        dist = td.Categorical(logits=logits.squeeze(0))
+        action = dist.sample()
+        logp = dist.log_prob(action)
+        onehot = nn.functional.one_hot(action, action_dim).float()
+
+        obs, reward, _, _, _ = env.step(int(action))
+        value = critic(seq, onehot.unsqueeze(0)).detach()
+        buffer.add(s, onehot, reward, value, logp.detach())
+
+        if buffer.ready():
+            s_batch, a_batch, r_batch, v_batch, lp_batch = buffer.get()
+            returns, adv = compute_gae(r_batch, v_batch)
+            ppo_update(actor, critic, opt_actor, opt_critic,
+                       s_batch, a_batch, lp_batch, returns, adv)
+
+    with torch.no_grad():
+        seq = torch.zeros(1, buffer.seq_len, state_dim)
+        logits = actor(seq)
+        print("Learned probs:", logits.softmax(-1))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bandit_env.py
+++ b/tests/test_bandit_env.py
@@ -1,0 +1,61 @@
+import torch
+import torch.nn as nn
+import torch.distributions as td
+import torch.optim as optim
+
+from envs.bandit_env import MultiArmedBanditEnv
+from models.ppo import ppo_update
+from utils.rollout import RolloutBufferNoDone, compute_gae
+
+
+def test_bandit_env_ppo():
+    env = MultiArmedBanditEnv([0.1, 0.9])
+    state_dim = env.observation_space.shape[0]
+    action_dim = env.action_space.n
+
+    class Actor(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(state_dim, action_dim)
+
+        def forward(self, seq):
+            return self.fc(seq[:, 0])
+
+    class Critic(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc = nn.Linear(state_dim + action_dim, 1)
+
+        def forward(self, seq, act):
+            x = torch.cat([seq[:, 0], act], dim=-1)
+            return self.fc(x).squeeze(-1)
+
+    actor = Actor()
+    critic = Critic()
+    opt_a = optim.Adam(actor.parameters(), lr=0.05)
+    opt_c = optim.Adam(critic.parameters(), lr=0.05)
+    buf = RolloutBufferNoDone(32, state_dim, action_dim, device="cpu")
+
+    obs, _ = env.reset()
+    for _ in range(200):
+        s = torch.tensor(obs, dtype=torch.float32)
+        seq = buf.get_latest_state_seq(s)
+        logits = actor(seq)
+        dist = td.Categorical(logits=logits.squeeze(0))
+        act = dist.sample()
+        logp = dist.log_prob(act)
+        onehot = nn.functional.one_hot(act, action_dim).float()
+        obs, rew, _, _, _ = env.step(int(act))
+        val = critic(seq, onehot.unsqueeze(0)).detach()
+        buf.add(s, onehot, rew, val, logp.detach())
+
+        if buf.ready():
+            s_b, a_b, r_b, v_b, lp_b = buf.get()
+            returns, adv = compute_gae(r_b, v_b)
+            ppo_update(actor, critic, opt_a, opt_c, s_b, a_b, lp_b, returns, adv)
+
+    with torch.no_grad():
+        seq = torch.zeros(1, buf.seq_len, state_dim)
+        logits = actor(seq)
+        best = logits.argmax().item()
+    assert best == 1


### PR DESCRIPTION
## Summary
- add a minimal multi-armed bandit environment
- expose bandit env in package
- provide a training example using PPO
- add a unit test that exercises PPO on the bandit environment

## Testing
- `pytest -q tests/test_bandit_env.py` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6865ce3a94dc832aa12b087046001338