### PR TITLE
Fix GAE index error & optional env imports

### DIFF
--- a/envs/__init__.py
+++ b/envs/__init__.py
@@ -1,4 +1,19 @@
-from .socket_env import SocketAppEnv
+"""Environment package exports.
+
+This module lazily imports optional environments so that the package can be used
+without requiring all optional dependencies (e.g. ``cv2``).  Tests that only
+need the bandit environment should still run even if other heavy dependencies
+are missing.
+"""
+
+try:
+    from .socket_env import SocketAppEnv  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may be missing
+    SocketAppEnv = None  # type: ignore
+
 from .bandit_env import MultiArmedBanditEnv
 
-__all__ = ["SocketAppEnv", "MultiArmedBanditEnv"]
+__all__ = [
+    "SocketAppEnv",
+    "MultiArmedBanditEnv",
+]


### PR DESCRIPTION
## Summary
- avoid importing heavy dependencies in `envs` when unused
- handle small buffers in `RolloutBufferNoDone`
- guard against empty inputs and zero variance in `compute_gae`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865df7085c0832aad8113f90f084c11