### PR TITLE
Fix PPO stability in bandit example

### DIFF
--- a/envs/bandit_env.py
+++ b/envs/bandit_env.py
@@ -5,23 +5,29 @@ class MultiArmedBanditEnv(gym.Env):
     """Simple multi-armed bandit environment for quick PPO tests."""
     metadata = {"render_modes": []}
 
-    def __init__(self, probs=None):
+    def __init__(self, probs=None, seed: int = 0):
         super().__init__()
         if probs is None:
             probs = [0.2, 0.5, 0.8]
         self.probs = np.array(probs, dtype=np.float32)
+        self.rng = np.random.default_rng(seed)
         self.n_actions = len(self.probs)
         self.action_space = gym.spaces.Discrete(self.n_actions)
+        # Cast ``action_space.n`` to ``int`` so downstream code using
+        # ``one_hot`` with ``action_dim`` works without type errors
+        self.action_space.n = int(self.action_space.n)
         self.observation_space = gym.spaces.Box(low=0.0, high=1.0, shape=(1,), dtype=np.float32)
         self.state = np.zeros(1, dtype=np.float32)
 
     def reset(self, seed=None, options=None):
+        if seed is not None:
+            self.rng = np.random.default_rng(seed)
         self.state.fill(0.0)
         return self.state.copy(), {}
 
     def step(self, action):
         p = self.probs[int(action)]
-        reward = 1.0 if np.random.random() < p else 0.0
+        reward = 1.0 if self.rng.random() < p else 0.0
         self.state[0] = reward
         return self.state.copy(), reward, False, False, {}
 

--- a/models/ppo.py
+++ b/models/ppo.py
@@ -47,7 +47,7 @@ def ppo_update(actor, critic, optim_actor, optim_critic,
 
             # Critic forward pass
             q_pred = critic(state_seq, actions)  # critic expects same seq
-            critic_loss = F.mse_loss(q_pred.squeeze(), returns)
+            critic_loss = F.mse_loss(q_pred, returns)
 
             loss = actor_loss + 0.5 * critic_loss
 

--- a/utils/rollout.py
+++ b/utils/rollout.py
@@ -125,7 +125,7 @@ def compute_gae(reward, value, gamma=0.995, lam=0.99):
         advantage[t] = gae
         returns[t]   = gae + value[t]
         next_val     = value[t]
-    std = advantage.std()
+    std = advantage.std(unbiased=False)
     if std > 1e-8:
         advantage = (advantage - advantage.mean()) / (std + 1e-8)
     else:  # avoid NaNs when variance is zero


### PR DESCRIPTION
## Summary
- normalize advantages deterministically
- fix critic loss dimension handling
- make bandit env deterministic and expose `seed`

## Testing
- `PYTHONPATH=. pytest tests/test_rollout_buffer.py::test_get_latest_state_seq_basic tests/test_bandit_env.py::test_bandit_env_ppo -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e76f24b4832ab897378adf5d26eb