### PR TITLE
Log action probs as per-action bins

### DIFF
--- a/examples/bandit_train.py
+++ b/examples/bandit_train.py
@@ -52,8 +52,9 @@ def main():
 
         obs, reward, _, _, _ = env.step(int(action))
         logger.log_scalar("Reward/Total", reward, step_count)
-        logger.log_histogram("Action/Probs",
-                             dist.probs.detach().cpu().numpy(), step_count)
+        action_probs = dist.probs.detach().cpu().numpy()
+        logger.log_histogram("Action/Probs", action_probs, step_count)
+        logger.log_action_bins("Action/Bins", action_probs, step_count)
         value = critic(seq, onehot.unsqueeze(0)).detach()
         buffer.add(s, onehot, reward, value, logp.detach())
 

--- a/main.py
+++ b/main.py
@@ -93,7 +93,9 @@ def main() -> None:
         obs, reward, terminated, truncated, _ = env.step(action.item())
         act_onehot = act_onehot.unsqueeze(0)
         logger.log_scalar("Reward/Total", reward, step_count)
-        logger.log_histogram("Action/Probs", dist.probs.squeeze(0).detach().cpu().numpy(), step_count)
+        action_probs = dist.probs.squeeze(0).detach().cpu().numpy()
+        logger.log_histogram("Action/Probs", action_probs, step_count)
+        logger.log_action_bins("Action/Bins", action_probs, step_count)
 
         value = critic(emb_seq, act_onehot.to(DEVICE)).squeeze().detach()
         logp_detached = logp.detach()

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -17,6 +17,13 @@ def log_histogram(tag: str, values: Iterable[float], step: int) -> None:
     _writer.add_histogram(tag, arr, step)
 
 
+def log_action_bins(tag: str, values: Iterable[float], step: int) -> None:
+    """Log per-action probabilities as individual scalar bins."""
+    arr = np.asarray(list(values), dtype=np.float32)
+    for idx, val in enumerate(arr):
+        _writer.add_scalar(f"{tag}/{idx}", float(val), step)
+
+
 def log_dict(metrics: Dict[str, Any], step: int) -> None:
     """Log multiple scalar metrics from a dictionary."""
     for k, v in metrics.items():


### PR DESCRIPTION
## Summary
- add `log_action_bins` in logger for discrete action probabilities
- log the new per-action bins in main training loop and bandit example

## Testing
- `pip install -r requirements.txt`
- `pip install numpy==1.26.4`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686621b9f908832a96f1b1f85178a644