### PR TITLE
Add LM Studio experiment folders

### DIFF
--- a/lab/lmstudio_api/README.md
+++ b/lab/lmstudio_api/README.md
@@ -1,0 +1,12 @@
+# LM Studio API Experiment
+
+This experiment demonstrates controlling the Undertale action server using the
+LM Studio Python SDK. The script captures frames from OBS Studio
+(video source `1`) via OpenCV and queries a locally running LM Studio instance
+for the next action index.
+
+## Files
+- `lmstudio_control.py` – captures one frame, sends a prompt to LM Studio and
+  forwards the predicted action to the UDP action server.
+
+LM Studio must be running locally for the script to connect.

--- a/lab/lmstudio_api/lmstudio_control.py
+++ b/lab/lmstudio_api/lmstudio_control.py
@@ -1,0 +1,45 @@
+import socket
+from utils.observations import LocalObs
+from lmstudio import Client
+
+# Address of the combined action server
+ACTION_ADDR = ("127.0.0.1", 5005)
+
+
+def send_action(action_idx: int) -> None:
+    """Send the chosen action index over UDP."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.sendto(str(action_idx).encode(), ACTION_ADDR)
+    sock.close()
+
+
+def query_action(client: Client, frame) -> int:
+    """Request the next action from LM Studio.
+
+    The LM is expected to reply with a plain integer in the range 0‑6.
+    """
+    prompt = "Given the current Undertale frame, respond with the next action index (0-6)."
+    params = {
+        "messages": [{"role": "user", "content": prompt}],
+        "response_format": {"type": "text"},
+    }
+    response = client.llm.remote_call("chat", params)
+    text = response["choices"][0]["message"]["content"].strip()
+    try:
+        return int(text)
+    except ValueError:
+        raise RuntimeError(f"Unexpected LM response: {text!r}")
+
+
+def main() -> None:
+    obs = LocalObs(source=1)
+    client = Client()
+    frame = obs.get_frame_224()
+    action = query_action(client, frame)
+    send_action(action)
+    obs.close()
+    client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/lab/structured_output/README.md
+++ b/lab/structured_output/README.md
@@ -1,0 +1,10 @@
+# LM Studio Structured Output
+
+This folder contains a small experiment using LM Studio's structured output
+feature. The configuration file defines a JSON schema for an object with a
+single field `action` which maps to the action index expected by the Undertale
+UDP server.
+
+The script `structured_control.py` captures one frame from OBS Studio (video
+source `1`), sends the structured request to LM Studio and forwards the
+predicted action to the action server.

--- a/lab/structured_output/structured_config.json
+++ b/lab/structured_output/structured_config.json
@@ -1,0 +1,11 @@
+{
+  "system_prompt": "You control Undertale via numeric action indices.",
+  "user_prompt": "Given the observation, return JSON with the next action.",
+  "schema": {
+    "type": "object",
+    "properties": {
+      "action": {"type": "integer", "minimum": 0, "maximum": 6}
+    },
+    "required": ["action"]
+  }
+}

--- a/lab/structured_output/structured_control.py
+++ b/lab/structured_output/structured_control.py
@@ -1,0 +1,49 @@
+import json
+import socket
+from pathlib import Path
+
+from utils.observations import LocalObs
+from lmstudio import Client
+
+CONFIG_PATH = Path(__file__).with_name("structured_config.json")
+ACTION_ADDR = ("127.0.0.1", 5005)
+
+
+def load_config() -> dict:
+    with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def send_action(action_idx: int) -> None:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.sendto(str(action_idx).encode(), ACTION_ADDR)
+    sock.close()
+
+
+def query_action(client: Client, config: dict, frame) -> int:
+    prompt = config["user_prompt"]
+    params = {
+        "messages": [
+            {"role": "system", "content": config["system_prompt"]},
+            {"role": "user", "content": prompt},
+        ],
+        "response_format": {"type": "json_object", "schema": config["schema"]},
+    }
+    response = client.llm.remote_call("chat", params)
+    data = json.loads(response["choices"][0]["message"]["content"])
+    return int(data["action"])
+
+
+def main() -> None:
+    obs = LocalObs(source=1)
+    client = Client()
+    config = load_config()
+    frame = obs.get_frame_224()
+    action = query_action(client, config, frame)
+    send_action(action)
+    obs.close()
+    client.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `lmstudio_api` example that connects LM Studio to the UDP action server
- add `structured_output` example showing structured JSON output

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686676d4fda4832a97f5e645f4db3c02