### PR TITLE
Fix LM Studio image upload

### DIFF
--- a/lab/lmstudio_api/lmstudio_control.py
+++ b/lab/lmstudio_api/lmstudio_control.py
@@ -38,7 +38,8 @@ def query_action(client: Client, frame) -> int:
     _, buffer = cv2.imencode(".png", frame)
     chat = Chat()
     chat.add_system_prompt(SYSTEM_PROMPT)
-    chat.add_user_message(USER_PROMPT, images=[buffer.tobytes()])
+    handle = client.prepare_image(buffer.tobytes(), name="frame.png")
+    chat.add_user_message(USER_PROMPT, images=[handle])
 
     model = client.llm.model()
     result = model.respond(


### PR DESCRIPTION
## Summary
- use `Client.prepare_image` to convert numpy bytes to an LM Studio file handle before adding the image to the chat

## Testing
- `python -m py_compile lab/lmstudio_api/lmstudio_control.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6868c01b1c90832a9f2c09c430de75e8