### PR TITLE
Fix world model scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ packages pinned in `requirements.txt`.
    `lab/scripts/rnn_lstm.pt` which was trained with an LSTM of hidden size
    512 and 3 layers:
 
+   Note that observations produced by `LocalObs` are scaled down by a
+   factor of ten. The environment scales them back up before sending them to
+   the world model server, which in turn divides its predictions by ten
+   before replying.
+
    ```bash
    python servers/world_model_server.py
    ```

--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -167,7 +167,7 @@ class SocketAppEnv(gym.Env):
             self.step_count % self.wm_interval_steps == 0 and
             perf_counter() - self._last_wm_time >= self.wm_time_interval
         ):
-            context = np.stack(self.obs_history, axis=0).astype(np.float32)
+            context = np.stack(self.obs_history, axis=0).astype(np.float32) * 10.0
             try:
                 self.wm_socket.settimeout(0.2)
                 self.wm_socket.sendto(context.tobytes(), self.wm_addr)

--- a/servers/world_model_server.py
+++ b/servers/world_model_server.py
@@ -72,6 +72,7 @@ def start_udp_world_model_server(model_path: str = DEFAULT_MODEL_PATH, host: str
                 else:
                     inp = obs_seq.unsqueeze(0)
                 pred = model(inp).squeeze(0).cpu().numpy().astype(np.float32)
+            pred /= 10.0
             sock.sendto(pred.tobytes(), addr)
     except KeyboardInterrupt:
         print('\n[WorldModelServer] Shutdown.')


### PR DESCRIPTION
## Summary
- scale observation sequences by 10 before sending to the world model server
- divide predictions by 10 on the server before returning
- document the scaling behaviour in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6868d1772ef4832a92aed8620d340c3f