### PR TITLE
Improve LM Studio integration and UDP resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ This repository implements a reinforcement learning setup that interacts with an
 * Extrinsic and intrinsic rewards are summed for each step.
 
 ## Action and Reward Server
-`servers/action_server.py` exposes `start_combined_udp_server` which wraps `ExternalRewardTracker` from `servers/reward_server.py` and processes both actions and reward queries on the same UDP port. Run this module to start the server.
+`servers/action_server.py` exposes `start_combined_udp_server` which wraps
+`ExternalRewardTracker` from `servers/reward_server.py` and processes both
+actions and reward queries on the same UDP port. The server now ignores
+`ConnectionResetError` events so occasional UDP connection resets on Windows do
+not terminate the process. Run this module to start the server.
 
 ## Neural Modules and PPO
 * `models/nn.py` contains LSTM based actor and critic networks.

--- a/lab/lmstudio_api/README.md
+++ b/lab/lmstudio_api/README.md
@@ -6,7 +6,9 @@ LM Studio Python SDK. The script captures frames from OBS Studio
 for the next action index.
 
 ## Files
-- `lmstudio_control.py` – captures one frame, sends a prompt to LM Studio and
-  forwards the predicted action to the UDP action server.
+ - `lmstudio_control.py` – captures a frame and queries LM Studio for the next
+   action. The helper preserves conversation history so repeated calls can
+   provide additional context to the model before sending the predicted action
+   to the UDP server.
 
 LM Studio must be running locally for the script to connect.


### PR DESCRIPTION
## Summary
- preserve LM Studio chat history between calls
- handle Windows connection resets in action server
- document chat history retention and UDP reset handling

## Testing
- `black lab/lmstudio_api/lmstudio_control.py servers/action_server.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686906b016cc832a864877edf3aab348