### PR TITLE
Fix world model reward interval

### DIFF
--- a/config.py
+++ b/config.py
@@ -24,6 +24,9 @@ class WorldModelConfig:
     model_path: str = "lab/scripts/mlp_world_model.pt"
     model_type: str = "mlp"  # "mlp", "gru" or "lstm"
     interval_steps: int = 15
+    # ``time_interval`` previously throttled requests based on wall clock.  The
+    # environment now relies solely on ``interval_steps`` so this field is kept
+    # for backward compatibility but is otherwise ignored.
     time_interval: float = 1.0
 
 


### PR DESCRIPTION
## Summary
- trigger world model reward only based on step intervals
- mark `WorldModelConfig.time_interval` as ignored

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686a59a6b574832a9fe0b80eaf89c1b3