### PR TITLE
Refactor SocketAppEnv with client utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ configuration object and pass its sections to the relevant modules.
 
 `SocketAppEnv` in `envs/socket_env.py` provides an OpenAI Gym environment. By default it communicates with two separate UDP ports: one for sending actions and one for requesting rewards. When the environment is created with `combined_server=True`, both actions and reward requests are sent to the same address. This mode is intended for use with the `start_combined_udp_server` helper defined in `servers/action_server.py`.
 
+Example usage with the new helper classes:
+
+```python
+from utils.udp_client import UdpClient
+from utils.observation_encoder import ObservationEncoder
+from envs.socket_env import SocketAppEnv
+
+udp = UdpClient(("127.0.0.1", 5005), ("127.0.0.1", 5006))
+encoder = ObservationEncoder(device="cuda")
+env = SocketAppEnv(udp_client=udp, obs_encoder=encoder, start_servers=False)
+```
+
 # Undertale RL via UDP
 
 This repository implements a reinforcement learning setup that interacts with an external application (e.g. Undertale) over UDP sockets. The main environment is `SocketAppEnv` in `envs/socket_env.py` which sends discrete actions and requests rewards from separate UDP endpoints. Observations are video frames encoded through a DINO model and combined with an intrinsic reward from `E3BIntrinsicReward`.

--- a/tests/test_bandit_env.py
+++ b/tests/test_bandit_env.py
@@ -1,3 +1,9 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
 import torch
 import torch.nn as nn
 import torch.distributions as td
@@ -9,6 +15,7 @@ from utils.rollout import RolloutBufferNoDone, compute_gae
 
 
 def test_bandit_env_ppo():
+    torch.manual_seed(0)
     env = MultiArmedBanditEnv([0.1, 0.9])
     state_dim = env.observation_space.shape[0]
     action_dim = env.action_space.n

--- a/tests/test_socket_env.py
+++ b/tests/test_socket_env.py
@@ -1,7 +1,5 @@
-import threading
-import socket
-import time
 import sys
+import numpy as np
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -15,39 +13,52 @@ except ModuleNotFoundError:
     SocketAppEnv = None
 
 
-def dummy_reward_server(host="127.0.0.1", port=9006, reward=1.0, stop_event=None):
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind((host, port))
-    sock.settimeout(0.1)
-    try:
-        while stop_event is None or not stop_event.is_set():
-            try:
-                data, addr = sock.recvfrom(64)
-            except socket.timeout:
-                continue
-            msg = data.decode().strip().upper()
-            if msg == "GET":
-                sock.sendto(str(reward).encode(), addr)
-            elif msg == "RESET":
-                sock.sendto(b"OK", addr)
-            else:
-                sock.sendto(b"ERR", addr)
-    finally:
-        sock.close()
+
+class DummyUdpClient:
+    def __init__(self, reward: float = 1.0):
+        self.reward = reward
+        self.actions = []
+
+    def send_action(self, action_idx: int) -> None:
+        self.actions.append(action_idx)
+
+    def send_reset(self) -> None:
+        pass
+
+    def get_reward(self) -> float:
+        return self.reward
+
+    def close(self) -> None:
+        pass
+
+
+class DummyObsEncoder:
+    def __init__(self, dim: int = 384):
+        self.dim = dim
+
+    def get_embedding(self) -> np.ndarray:
+        return np.zeros(self.dim, dtype=np.float32)
+
+    def close(self):
+        pass
 
 
 def test_socket_env_basic():
     if SocketAppEnv is None:
         pytest.skip("gymnasium not installed")
-    stop = threading.Event()
-    server_thread = threading.Thread(target=dummy_reward_server, kwargs={"stop_event": stop})
-    server_thread.daemon = True
-    server_thread.start()
-    time.sleep(0.1)
-
-    env = SocketAppEnv(max_steps=1, device="cpu", action_host="127.0.0.1", action_port=9005,
-                       reward_host="127.0.0.1", reward_port=9006,
-                       embedding_model=None, combined_server=False, enable_logging=False)
+    udp = DummyUdpClient(reward=1.0)
+    obs_enc = DummyObsEncoder()
+    env = SocketAppEnv(
+        max_steps=1,
+        device="cpu",
+        embedding_model=None,
+        combined_server=False,
+        enable_logging=False,
+        start_servers=False,
+        use_world_model=False,
+        udp_client=udp,
+        obs_encoder=obs_enc,
+    )
     obs, _ = env.reset()
     assert hasattr(obs, "shape")
     assert len(obs) == env.state_dim
@@ -59,5 +70,4 @@ def test_socket_env_basic():
     assert truncated
 
     env.close()
-    stop.set()
-    server_thread.join(timeout=1)
+

--- a/utils/observation_encoder.py
+++ b/utils/observation_encoder.py
@@ -1,0 +1,24 @@
+from typing import Optional
+import numpy as np
+
+from utils.observations import LocalObs
+
+class ObservationEncoder:
+    """Wrapper for ``LocalObs`` providing DINO embeddings."""
+    def __init__(self,
+                 source: int = 1,
+                 model_name: Optional[str] = "facebook/dinov2-with-registers-small",
+                 device: str = "cpu",
+                 embedding_dim: int = 384):
+        self._obs = LocalObs(source=source,
+                             mode="dino",
+                             model_name=model_name,
+                             device=device,
+                             embedding_dim=embedding_dim)
+
+    def get_embedding(self) -> np.ndarray:
+        return self._obs.get_embedding()
+
+    def close(self) -> None:
+        self._obs.close()
+

--- a/utils/udp_client.py
+++ b/utils/udp_client.py
@@ -1,0 +1,50 @@
+import socket
+from typing import Tuple
+
+class UdpClient:
+    """Simple UDP helper for sending actions and requesting rewards."""
+    def __init__(self,
+                 action_addr: Tuple[str, int],
+                 reward_addr: Tuple[str, int],
+                 combined_server: bool = False,
+                 timeout: float = 0.2):
+        self.action_addr = action_addr
+        self.reward_addr = reward_addr if not combined_server else action_addr
+        self.combined_server = combined_server
+
+        self.action_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        if combined_server:
+            self.reward_socket = self.action_socket
+        else:
+            self.reward_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.reward_socket.settimeout(timeout)
+
+    def send_action(self, action_idx: int) -> None:
+        msg = str(action_idx).encode()
+        self.action_socket.sendto(msg, self.action_addr)
+        if self.combined_server:
+            try:
+                self.reward_socket.recvfrom(32)
+            except Exception:
+                pass
+
+    def send_reset(self) -> None:
+        try:
+            self.reward_socket.sendto(b"RESET", self.reward_addr)
+            self.reward_socket.recvfrom(32)
+        except Exception:
+            pass
+
+    def get_reward(self) -> float:
+        try:
+            self.reward_socket.sendto(b"GET", self.reward_addr)
+            data, _ = self.reward_socket.recvfrom(32)
+            return float(data.decode().strip())
+        except Exception:
+            return 0.0
+
+    def close(self) -> None:
+        self.action_socket.close()
+        if not self.combined_server:
+            self.reward_socket.close()
+

--- a/utils/world_model_client.py
+++ b/utils/world_model_client.py
@@ -1,0 +1,20 @@
+import socket
+from typing import Tuple
+import numpy as np
+
+class WorldModelClient:
+    """UDP client that queries a world model server for predictions."""
+    def __init__(self, addr: Tuple[str, int], timeout: float = 0.2):
+        self.addr = addr
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.settimeout(timeout)
+
+    def predict(self, obs_sequence: np.ndarray) -> np.ndarray:
+        """Send an observation sequence and return the predicted next embedding."""
+        self.sock.sendto(obs_sequence.tobytes(), self.addr)
+        data, _ = self.sock.recvfrom(65535)
+        return np.frombuffer(data, dtype=np.float32)
+
+    def close(self) -> None:
+        self.sock.close()
+


### PR DESCRIPTION
## Summary
- add UDP and world model client helpers
- wrap observation capture/embedding with ObservationEncoder
- refactor `SocketAppEnv` to use injectable components
- adjust unit tests to avoid real UDP sockets
- document new helper usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7a918b40832a9069fbdccd5fe535