### PR TITLE
Allow custom intrinsic reward modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ env = SocketAppEnv(udp_client=udp, obs_encoder=encoder, start_servers=False)
 
 # Undertale RL via UDP
 
-This repository implements a reinforcement learning setup that interacts with an external application (e.g. Undertale) over UDP sockets. The main environment is `SocketAppEnv` in `envs/socket_env.py` which sends discrete actions and requests rewards from separate UDP endpoints. Observations are video frames encoded through a DINO model and combined with an intrinsic reward from `E3BIntrinsicReward`.
+This repository implements a reinforcement learning setup that interacts with an external application (e.g. Undertale) over UDP sockets. The main environment is `SocketAppEnv` in `envs/socket_env.py` which sends discrete actions and requests rewards from separate UDP endpoints. Observations are video frames encoded through a DINO model and combined with an intrinsic reward from `E3BIntrinsicReward` by default. Any module implementing the `BaseIntrinsicReward` interface can be passed via the `intrinsic_reward` parameter for custom curiosity bonuses.
 
 ## Environment Workflow
 * Actions are sent over UDP to a keyboard server.
 * Extrinsic rewards are fetched from another UDP port.
-* Observations are encoded with `LocalObs` and passed into `E3BIntrinsicReward` for novelty bonuses.
+* Observations are encoded with `LocalObs` and passed into an intrinsic reward module for novelty bonuses (defaults to `E3BIntrinsicReward`).
 * Extrinsic and intrinsic rewards are summed for each step.
 
 ## Action and Reward Server

--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -17,7 +17,7 @@ from typing import Optional, Callable
 from config import EnvConfig
 
 from utils.observation_encoder import ObservationEncoder
-from utils.intrinsic import E3BIntrinsicReward
+from utils.intrinsic import BaseIntrinsicReward, E3BIntrinsicReward
 from utils.cosine import cosine_distance
 from utils.udp_client import UdpClient
 from utils.world_model_client import WorldModelClient
@@ -49,6 +49,7 @@ class SocketAppEnv(gym.Env):
         udp_client: Optional[UdpClient] = None,
         world_model_client: Optional[WorldModelClient] = None,
         obs_encoder: Optional[ObservationEncoder] = None,
+        intrinsic_reward: Optional[BaseIntrinsicReward] = None,
         server_launcher: Optional[Callable[["SocketAppEnv"], None]] = None,
     ):
 
@@ -111,8 +112,18 @@ class SocketAppEnv(gym.Env):
             self.wm_client = None
         self.obs_history = []
 
-        self.obs_encoder = obs_encoder or ObservationEncoder(source=1, model_name=embedding_model, device=device, embedding_dim=state_dim)
-        self.intrinsic = E3BIntrinsicReward(latent_dim=state_dim, decay=1.0, ridge=0.1, device=device)
+        self.obs_encoder = obs_encoder or ObservationEncoder(
+            source=1,
+            model_name=embedding_model,
+            device=device,
+            embedding_dim=state_dim,
+        )
+        self.intrinsic = intrinsic_reward or E3BIntrinsicReward(
+            latent_dim=state_dim,
+            decay=1.0,
+            ridge=0.1,
+            device=device,
+        )
 
         if self.enable_logging:
             from utils import logger

--- a/utils/intrinsic.py
+++ b/utils/intrinsic.py
@@ -1,6 +1,18 @@
 import torch
 
-class E3BIntrinsicReward:
+
+class BaseIntrinsicReward:
+    """Interface for plug-in curiosity reward modules."""
+
+    def reset(self) -> None:  # pragma: no cover - interface method
+        """Reset any internal state maintained by the module."""
+        raise NotImplementedError
+
+    def compute(self, h):  # pragma: no cover - interface method
+        """Return the intrinsic reward for the given embedding."""
+        raise NotImplementedError
+
+class E3BIntrinsicReward(BaseIntrinsicReward):
     def __init__(self, latent_dim=384, decay=0.9995, ridge=0.1, device="cpu"):
         """
         Args:


### PR DESCRIPTION
## Summary
- make intrinsic reward pluggable by introducing `BaseIntrinsicReward`
- update `SocketAppEnv` to accept an `intrinsic_reward` instance
- document the new interface in README
- test custom intrinsic reward injection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686baa7b339c832ab0f977c1ad827327