### PR TITLE
Add configurable curiosity reward interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,21 @@ env = SocketAppEnv(udp_client=udp, obs_encoder=encoder, start_servers=False)
 
 # Undertale RL via UDP
 
-This repository implements a reinforcement learning setup that interacts with an external application (e.g. Undertale) over UDP sockets. The main environment is `SocketAppEnv` in `envs/socket_env.py` which sends discrete actions and requests rewards from separate UDP endpoints. Observations are video frames encoded through a DINO model and combined with an intrinsic reward from `E3BIntrinsicReward` by default. Any module implementing the `BaseIntrinsicReward` interface can be passed via the `intrinsic_reward` parameter for custom curiosity bonuses.
+This repository implements a reinforcement learning setup that interacts with an external application (e.g. Undertale) over UDP sockets. The main environment is `SocketAppEnv` in `envs/socket_env.py` which sends discrete actions and requests rewards from separate UDP endpoints. Observations are video frames encoded through a DINO model and combined with an intrinsic reward from `E3BIntrinsicReward` by default. Any module implementing the `CuriosityReward` interface can be passed via the `intrinsic_reward` parameter or loaded via the configuration for custom curiosity bonuses.
 
 ## Environment Workflow
 * Actions are sent over UDP to a keyboard server.
 * Extrinsic rewards are fetched from another UDP port.
 * Observations are encoded with `LocalObs` and passed into an intrinsic reward module for novelty bonuses (defaults to `E3BIntrinsicReward`).
+  Custom modules implementing ``CuriosityReward`` can be configured via ``EnvConfig.intrinsic_reward``.
 * Extrinsic and intrinsic rewards are summed for each step.
+
+### Custom Curiosity Modules
+The environment can dynamically load a curiosity plugin via the
+``EnvConfig.intrinsic_reward`` settings. Each plugin must implement the
+``CuriosityReward`` interface which defines ``reset()`` and ``compute(obs, env)``.
+See ``examples/custom_curiosity.py`` for a minimal example returning a constant
+bonus.
 
 ## Action and Reward Server
 `servers/action_server.py` exposes `start_combined_udp_server` which wraps

--- a/config.py
+++ b/config.py
@@ -25,6 +25,13 @@ class WorldModelConfig:
     model_type: str = "lstm"  # "mlp", "gru" or "lstm"
     interval_steps: int = 15
 
+
+@dataclass
+class IntrinsicRewardConfig:
+    """Location of the curiosity reward module."""
+    module_path: str = "utils.intrinsic"
+    class_name: str = "E3BIntrinsicReward"
+
 @dataclass
 class EnvConfig:
     """Default parameters for ``SocketAppEnv``."""
@@ -42,6 +49,7 @@ class EnvConfig:
     enable_logging: bool = True
     use_world_model: bool = True
     world_model: WorldModelConfig = field(default_factory=WorldModelConfig)
+    intrinsic_reward: IntrinsicRewardConfig = field(default_factory=IntrinsicRewardConfig)
 
 
 @dataclass

--- a/examples/custom_curiosity.py
+++ b/examples/custom_curiosity.py
@@ -1,0 +1,13 @@
+from utils.curiosity_base import CuriosityReward
+
+class ConstantCuriosity(CuriosityReward):
+    """Simple curiosity module returning a constant bonus."""
+
+    def __init__(self, value: float = 1.0):
+        self.value = value
+
+    def reset(self) -> None:
+        pass
+
+    def compute(self, obs, env):
+        return float(self.value)

--- a/utils/curiosity_base.py
+++ b/utils/curiosity_base.py
@@ -1,0 +1,10 @@
+class CuriosityReward:
+    """Interface for intrinsic reward modules."""
+
+    def reset(self) -> None:  # pragma: no cover - interface
+        """Reset the internal state if any."""
+        raise NotImplementedError
+
+    def compute(self, obs, env):  # pragma: no cover - interface
+        """Return intrinsic reward for observation in the given environment."""
+        raise NotImplementedError

--- a/utils/intrinsic.py
+++ b/utils/intrinsic.py
@@ -1,18 +1,8 @@
 import torch
 
+from .curiosity_base import CuriosityReward
 
-class BaseIntrinsicReward:
-    """Interface for plug-in curiosity reward modules."""
-
-    def reset(self) -> None:  # pragma: no cover - interface method
-        """Reset any internal state maintained by the module."""
-        raise NotImplementedError
-
-    def compute(self, h):  # pragma: no cover - interface method
-        """Return the intrinsic reward for the given embedding."""
-        raise NotImplementedError
-
-class E3BIntrinsicReward(BaseIntrinsicReward):
+class E3BIntrinsicReward(CuriosityReward):
     def __init__(self, latent_dim=384, decay=0.9995, ridge=0.1, device="cpu"):
         """
         Args:
@@ -31,7 +21,7 @@ class E3BIntrinsicReward(BaseIntrinsicReward):
         """Reset the inverse covariance matrix to its initial state."""
         self.cov_inverse = torch.eye(self.latent_dim, device=self.device) * (1.0 / self.ridge)
 
-    def compute(self, h):
+    def compute(self, h, env=None):
         """
         Compute E3B intrinsic reward for a given embedding and update covariance.
         Args:


### PR DESCRIPTION
## Summary
- create `CuriosityReward` base class
- make `E3BIntrinsicReward` extend `CuriosityReward`
- allow `SocketAppEnv` to dynamically load a curiosity plugin via config
- add `IntrinsicRewardConfig` to config
- show example curiosity module and document usage
- test curiosity injection through config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686baf604364832a86601d184f5ffccb