### PR TITLE
Add IntrinsicReward interface default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ env = SocketAppEnv(udp_client=udp, obs_encoder=encoder, start_servers=False)
 
 # Undertale RL via UDP
 
-This repository implements a reinforcement learning setup that interacts with an external application (e.g. Undertale) over UDP sockets. The main environment is `SocketAppEnv` in `envs/socket_env.py` which sends discrete actions and requests rewards from separate UDP endpoints. Observations are video frames encoded through a DINO model and combined with an intrinsic reward from `E3BIntrinsicReward` by default. Any module implementing the `CuriosityReward` interface can be passed via the `intrinsic_reward` parameter or loaded via the configuration for custom curiosity bonuses.
+This repository implements a reinforcement learning setup that interacts with an external application (e.g. Undertale) over UDP sockets. The main environment is `SocketAppEnv` in `envs/socket_env.py` which sends discrete actions and requests rewards from separate UDP endpoints. Observations are video frames encoded through a DINO model and combined with an intrinsic reward from `E3BIntrinsicReward` by default. Any module implementing the `IntrinsicReward` interface can be passed via the `intrinsic_reward` parameter or loaded via the configuration for custom curiosity bonuses.
 
 ## Environment Workflow
 * Actions are sent over UDP to a keyboard server.
 * Extrinsic rewards are fetched from another UDP port.
 * Observations are encoded with `LocalObs` and passed into an intrinsic reward module for novelty bonuses (defaults to `E3BIntrinsicReward`).
-  Custom modules implementing ``CuriosityReward`` can be configured via ``EnvConfig.intrinsic_reward``.
+  Custom modules implementing ``IntrinsicReward`` can be configured via ``EnvConfig.intrinsic_reward``.
 * Extrinsic and intrinsic rewards are summed for each step.
 
 ### Custom Curiosity Modules
 The environment can dynamically load a curiosity plugin via the
 ``EnvConfig.intrinsic_reward`` settings. Each plugin must implement the
-``CuriosityReward`` interface which defines ``reset()`` and ``compute(obs, env)``.
+``IntrinsicReward`` interface which defines ``reset()`` and ``compute(obs, env)``.
 See ``examples/custom_curiosity.py`` for a minimal example returning a constant
 bonus.
 

--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -18,7 +18,7 @@ from typing import Optional, Callable
 from config import EnvConfig
 
 from utils.observation_encoder import ObservationEncoder
-from utils.curiosity_base import CuriosityReward
+from utils.curiosity_base import CuriosityReward, IntrinsicReward
 from utils.intrinsic import E3BIntrinsicReward
 from utils.cosine import cosine_distance
 from utils.udp_client import UdpClient
@@ -51,7 +51,7 @@ class SocketAppEnv(gym.Env):
         udp_client: Optional[UdpClient] = None,
         world_model_client: Optional[WorldModelClient] = None,
         obs_encoder: Optional[ObservationEncoder] = None,
-        intrinsic_reward: Optional[CuriosityReward] = None,
+        intrinsic_reward: Optional[IntrinsicReward] = None,
         server_launcher: Optional[Callable[["SocketAppEnv"], None]] = None,
     ):
 


### PR DESCRIPTION
## Summary
- update README to mention `IntrinsicReward`
- change `SocketAppEnv` constructor type to `Optional[IntrinsicReward]`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bbed80540832abec40ca3e6d92cbe