### PR TITLE
Add intrinsic reward example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,31 @@ This repository implements a reinforcement learning setup that interacts with an
 The environment can dynamically load a curiosity plugin via the
 ``EnvConfig.intrinsic_reward`` settings. Each plugin must implement the
 ``IntrinsicReward`` interface which defines ``reset()`` and ``compute(obs, env)``.
-See ``examples/custom_curiosity.py`` for a minimal example returning a constant
+
+Minimal example implementing a constant bonus:
+
+```python
+from utils.curiosity_base import IntrinsicReward
+
+class MyReward(IntrinsicReward):
+    def reset(self) -> None:
+        pass
+
+    def compute(self, observation, env) -> float:
+        return 1.0
+
+# Direct instantiation
+env = SocketAppEnv(intrinsic_reward=MyReward(), start_servers=False)
+
+# Or via configuration
+from config import get_config
+cfg = get_config()
+cfg.env.intrinsic_reward.module_path = "examples.custom_curiosity"
+cfg.env.intrinsic_reward.class_name = "MyReward"
+env = SocketAppEnv(config=cfg.env, start_servers=False)
+```
+
+See ``examples/custom_curiosity.py`` for a complete module returning a constant
 bonus.
 
 ## Action and Reward Server

--- a/examples/custom_curiosity.py
+++ b/examples/custom_curiosity.py
@@ -1,6 +1,8 @@
-from utils.curiosity_base import CuriosityReward
+"""Minimal custom curiosity module returning a constant bonus."""
 
-class ConstantCuriosity(CuriosityReward):
+from utils.curiosity_base import IntrinsicReward
+
+class ConstantCuriosity(IntrinsicReward):
     """Simple curiosity module returning a constant bonus."""
 
     def __init__(self, value: float = 1.0):
@@ -9,5 +11,5 @@ class ConstantCuriosity(CuriosityReward):
     def reset(self) -> None:
         pass
 
-    def compute(self, obs, env):
+    def compute(self, observation, env) -> float:
         return float(self.value)


### PR DESCRIPTION
## Summary
- document how to implement a custom `IntrinsicReward`
- show passing a reward instance or loading via config
- update `examples/custom_curiosity.py` to implement `IntrinsicReward`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc1fcdce4832ab48a7d62310cfdeb