### PR TITLE
Remove unused world_model_time parameter

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -74,7 +74,6 @@ class SocketAppEnv(gym.Env):
             world_model_path = config.world_model.model_path
             world_model_type = config.world_model.model_type
             world_model_interval = config.world_model.interval_steps
-            world_model_time = getattr(config.world_model, "time_interval", None)  # unused
             ir_config = getattr(config, "intrinsic_reward", None)
             intrinsic_cls_path = getattr(config, "intrinsic_cls", None)
         else:
@@ -105,9 +104,6 @@ class SocketAppEnv(gym.Env):
         self.world_model_path = world_model_path
         self.world_model_type = world_model_type
         self.wm_interval_steps = int(max(1, world_model_interval))
-        # ``world_model_time`` was previously used to throttle requests based on
-        # wall clock.  The reward from the world model is now triggered purely
-        # on step intervals to avoid irregular spacing in the logged values.
         self._server_processes = []
         self._logger = None
         self._last_action_time = perf_counter()

--- a/examples/random_agent.py
+++ b/examples/random_agent.py
@@ -22,7 +22,6 @@ def main():
         world_model_path=cfg.env.world_model.model_path,
         world_model_type=cfg.env.world_model.model_type,
         world_model_interval=cfg.env.world_model.interval_steps,
-        world_model_time=cfg.env.world_model.time_interval,
     )
     obs, _ = env.reset()
     print(f"Initial obs shape: {obs.shape}")

--- a/examples/stable_ppo.py
+++ b/examples/stable_ppo.py
@@ -44,7 +44,6 @@ def make_env(name: str) -> Callable[[], gym.Env]:
                 world_model_path=cfg.env.world_model.model_path,
                 world_model_type=cfg.env.world_model.model_type,
                 world_model_interval=cfg.env.world_model.interval_steps,
-                world_model_time=cfg.env.world_model.time_interval,
             )
         return _f
     raise ValueError(f"Unknown env '{name}'")

--- a/main.py
+++ b/main.py
@@ -68,7 +68,6 @@ def main() -> None:
             world_model_path=cfg.env.world_model.model_path,
             world_model_type=cfg.env.world_model.model_type,
             world_model_interval=cfg.env.world_model.interval_steps,
-            world_model_time=cfg.env.world_model.time_interval,
         )
         vec_env = make_vec_env(env_fn, n_envs=1)
         model = SB3PPO(


### PR DESCRIPTION
## Summary
- drop `world_model_time` argument in `SocketAppEnv`
- remove associated options in examples and training script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686bc86ba110832aa99703b491f4b82e