### PR TITLE
Fix critic layer dimension

### DIFF
--- a/models/nn.py
+++ b/models/nn.py
@@ -29,8 +29,7 @@ class Q_Critic(nn.Module):
         self.lstm = shared_lstm
         self.lstm_hidden = self.lstm.hidden_size
 
-        #self.fc1 = nn.Linear(self.lstm_hidden + action_dim, net_width)
-        self.fc1 = nn.Linear(263, net_width)
+        self.fc1 = nn.Linear(self.lstm_hidden + action_dim, net_width)
         self.fc2 = nn.Linear(net_width, 1)
 
     def forward(self, state_seq, action):


### PR DESCRIPTION
## Summary
- fix Q_Critic fc1 layer dimension so it adapts to the network

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686bcd8e0114832a948a8638c68ec86a