### PR TITLE
Add create_socket_env helper

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -23,6 +23,7 @@ from utils.intrinsic import E3BIntrinsicReward, BaseIntrinsicReward
 from utils.cosine import cosine_distance
 from utils.udp_client import UdpClient
 from utils.world_model_client import WorldModelClient
+from dataclasses import asdict
 
 class SocketAppEnv(gym.Env):
     metadata = {"render_modes": []}
@@ -284,3 +285,20 @@ class SocketAppEnv(gym.Env):
             ]
             p = subprocess.Popen(cmd)
             self._server_processes.append(p)
+
+
+def create_socket_env(cfg: EnvConfig) -> SocketAppEnv:
+    """Instantiate ``SocketAppEnv`` from an ``EnvConfig``."""
+    env_kwargs = asdict(cfg)
+    wm = env_kwargs.pop("world_model")
+    env_kwargs.update({
+        "world_model_host": wm["host"],
+        "world_model_port": wm["port"],
+        "world_model_path": wm["model_path"],
+        "world_model_type": wm["model_type"],
+        "world_model_interval": wm["interval_steps"],
+    })
+    env_kwargs.pop("intrinsic_reward", None)
+    env_kwargs.pop("intrinsic_cls", None)
+    env_kwargs["config"] = cfg
+    return SocketAppEnv(**env_kwargs)

--- a/examples/random_agent.py
+++ b/examples/random_agent.py
@@ -1,28 +1,9 @@
-from envs.socket_env import SocketAppEnv
+from envs.socket_env import create_socket_env
 from config import get_config
 
 def main():
     cfg = get_config()
-    env = SocketAppEnv(
-        cfg.env.max_steps,
-        device=cfg.env.device,
-        action_dim=cfg.env.action_dim,
-        state_dim=cfg.env.state_dim,
-        action_host=cfg.env.action_host,
-        action_port=cfg.env.action_port,
-        reward_host=cfg.env.reward_host,
-        reward_port=cfg.env.reward_port,
-        embedding_model=cfg.env.embedding_model,
-        combined_server=cfg.env.combined_server,
-        start_servers=cfg.env.start_servers,
-        enable_logging=cfg.env.enable_logging,
-        use_world_model=cfg.env.use_world_model,
-        world_model_host=cfg.env.world_model.host,
-        world_model_port=cfg.env.world_model.port,
-        world_model_path=cfg.env.world_model.model_path,
-        world_model_type=cfg.env.world_model.model_type,
-        world_model_interval=cfg.env.world_model.interval_steps,
-    )
+    env = create_socket_env(cfg.env)
     obs, _ = env.reset()
     print(f"Initial obs shape: {obs.shape}")
     for step in range(1000):

--- a/examples/stable_ppo.py
+++ b/examples/stable_ppo.py
@@ -7,7 +7,7 @@ from stable_baselines3.common.env_util import make_vec_env
 
 from envs.bandit_env import MultiArmedBanditEnv
 from envs.continuous_bandit_env import ContinuousBanditEnv
-from envs.socket_env import SocketAppEnv
+from envs.socket_env import create_socket_env
 from config import get_config
 
 
@@ -25,26 +25,7 @@ def make_env(name: str) -> Callable[[], gym.Env]:
         cfg = get_config()
 
         def _f() -> gym.Env:
-            return SocketAppEnv(
-                cfg.env.max_steps,
-                device=cfg.env.device,
-                action_dim=cfg.env.action_dim,
-                state_dim=cfg.env.state_dim,
-                action_host=cfg.env.action_host,
-                action_port=cfg.env.action_port,
-                reward_host=cfg.env.reward_host,
-                reward_port=cfg.env.reward_port,
-                embedding_model=cfg.env.embedding_model,
-                combined_server=cfg.env.combined_server,
-                start_servers=cfg.env.start_servers,
-                enable_logging=cfg.env.enable_logging,
-                use_world_model=cfg.env.use_world_model,
-                world_model_host=cfg.env.world_model.host,
-                world_model_port=cfg.env.world_model.port,
-                world_model_path=cfg.env.world_model.model_path,
-                world_model_type=cfg.env.world_model.model_type,
-                world_model_interval=cfg.env.world_model.interval_steps,
-            )
+            return create_socket_env(cfg.env)
         return _f
     raise ValueError(f"Unknown env '{name}'")
 

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from pynput import keyboard
 from utils import logger
 from config import get_config
 
-from envs.socket_env import SocketAppEnv
+from envs.socket_env import SocketAppEnv, create_socket_env
 from models.nn import Actor, Q_Critic
 from utils.rollout import RolloutBufferNoDone, compute_gae
 from models.ppo import ppo_update
@@ -49,26 +49,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.sb3:
-        env_fn = lambda: SocketAppEnv(
-            cfg.env.max_steps,
-            device=cfg.env.device,
-            action_dim=cfg.env.action_dim,
-            state_dim=cfg.env.state_dim,
-            action_host=cfg.env.action_host,
-            action_port=cfg.env.action_port,
-            reward_host=cfg.env.reward_host,
-            reward_port=cfg.env.reward_port,
-            embedding_model=cfg.env.embedding_model,
-            combined_server=cfg.env.combined_server,
-            start_servers=cfg.env.start_servers,
-            enable_logging=cfg.env.enable_logging,
-            use_world_model=cfg.env.use_world_model,
-            world_model_host=cfg.env.world_model.host,
-            world_model_port=cfg.env.world_model.port,
-            world_model_path=cfg.env.world_model.model_path,
-            world_model_type=cfg.env.world_model.model_type,
-            world_model_interval=cfg.env.world_model.interval_steps,
-        )
+        env_fn = lambda: create_socket_env(cfg.env)
         vec_env = make_vec_env(env_fn, n_envs=1)
         model = SB3PPO(
             "MlpPolicy",
@@ -87,26 +68,7 @@ def main() -> None:
 
     Thread(target=hotkey_listener, daemon=True).start()
 
-    env = SocketAppEnv(
-        cfg.env.max_steps,
-        device=cfg.env.device,
-        action_dim=cfg.env.action_dim,
-        state_dim=cfg.env.state_dim,
-        action_host=cfg.env.action_host,
-        action_port=cfg.env.action_port,
-        reward_host=cfg.env.reward_host,
-        reward_port=cfg.env.reward_port,
-        embedding_model=cfg.env.embedding_model,
-        combined_server=cfg.env.combined_server,
-        start_servers=cfg.env.start_servers,
-        enable_logging=cfg.env.enable_logging,
-        use_world_model=cfg.env.use_world_model,
-        world_model_host=cfg.env.world_model.host,
-        world_model_port=cfg.env.world_model.port,
-        world_model_path=cfg.env.world_model.model_path,
-        world_model_type=cfg.env.world_model.model_type,
-        world_model_interval=cfg.env.world_model.interval_steps,
-    )
+    env = create_socket_env(cfg.env)
     obs, _ = env.reset()
 
     actor = Actor(state_dim=STATE_DIM, action_dim=ACTION_DIM).to(DEVICE)


### PR DESCRIPTION
## Summary
- add `create_socket_env` to envs.socket_env
- use the helper in main.py and example scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bcd91b054832a83f19b6bf01b3906