### PR TITLE
Remove unused imports

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -1,12 +1,10 @@
 import gymnasium as gym
 import numpy as np
 import socket
-import torch
 import subprocess
 import sys
 import importlib
 from time import sleep, perf_counter
-from threading import Thread, Event
 from servers.constants import (
     ARROW_DELAY,
     WAIT_DELAY,
@@ -18,7 +16,7 @@ from typing import Optional, Callable
 from config import EnvConfig
 
 from utils.observation_encoder import ObservationEncoder
-from utils.curiosity_base import CuriosityReward, IntrinsicReward
+from utils.curiosity_base import IntrinsicReward
 from utils.intrinsic import E3BIntrinsicReward, BaseIntrinsicReward
 from utils.cosine import cosine_distance
 from utils.udp_client import UdpClient


### PR DESCRIPTION
## Summary
- tidy socket environment by dropping unused imports

## Testing
- `flake8 envs/socket_env.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_686bd323b024832ab3518cf6fd3e45e7