### PR TITLE
Add pause sleep to reduce CPU usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import torch.distributions as td
 from stable_baselines3 import PPO as SB3PPO
 from stable_baselines3.common.env_util import make_vec_env
 from time import sleep
+import time
 from threading import Thread
 from pynput import keyboard
 from utils import logger
@@ -87,6 +88,7 @@ def main() -> None:
 
     while True:
         if paused:
+            time.sleep(0.05)
             continue
 
         state_tensor = torch.from_numpy(obs).float()


### PR DESCRIPTION
## Summary
- prevent busy waiting when training is paused
- import `time` for main loop sleep

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd68d4468832a892e56eafec5296e