### PR TITLE
Add context manager methods for UDP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ from utils.udp_client import UdpClient
 from utils.observation_encoder import ObservationEncoder
 from envs.socket_env import SocketAppEnv
 
-udp = UdpClient(("127.0.0.1", 5005), ("127.0.0.1", 5006))
-encoder = ObservationEncoder(device="cuda")
-env = SocketAppEnv(udp_client=udp, obs_encoder=encoder, start_servers=False)
+with UdpClient(("127.0.0.1", 5005), ("127.0.0.1", 5006)) as udp:
+    encoder = ObservationEncoder(device="cuda")
+    env = SocketAppEnv(udp_client=udp, obs_encoder=encoder, start_servers=False)
 ```
 
 # Undertale RL via UDP

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -59,15 +59,14 @@ def test_udp_client_send_action_and_get_reward():
     t1.start()
     t2.start()
 
-    client = UdpClient(("127.0.0.1", action_port), ("127.0.0.1", reward_port))
-    client.send_action(3)
-    reward = client.get_reward()
-    client.send_reset()
+    with UdpClient(("127.0.0.1", action_port), ("127.0.0.1", reward_port)) as client:
+        client.send_action(3)
+        reward = client.get_reward()
+        client.send_reset()
 
     stop_event.set()
     t1.join(timeout=1)
     t2.join(timeout=1)
-    client.close()
     action_sock.close()
     reward_sock.close()
 
@@ -96,13 +95,12 @@ def test_world_model_client_predict():
     t = threading.Thread(target=model_server, daemon=True)
     t.start()
 
-    client = WorldModelClient(("127.0.0.1", port))
-    obs = np.zeros((2, 3), dtype=np.float32)
-    pred = client.predict(obs)
+    with WorldModelClient(("127.0.0.1", port)) as client:
+        obs = np.zeros((2, 3), dtype=np.float32)
+        pred = client.predict(obs)
 
     stop_event.set()
     t.join(timeout=1)
-    client.close()
     sock.close()
 
     assert np.allclose(pred, obs.flatten() + 1)

--- a/tests/test_udp_world_clients.py
+++ b/tests/test_udp_world_clients.py
@@ -59,15 +59,14 @@ def test_udp_client_basic_roundtrip():
     t1.start()
     t2.start()
 
-    client = UdpClient(("127.0.0.1", action_port), ("127.0.0.1", reward_port))
-    client.send_action(5)
-    r = client.get_reward()
-    client.send_reset()
+    with UdpClient(("127.0.0.1", action_port), ("127.0.0.1", reward_port)) as client:
+        client.send_action(5)
+        r = client.get_reward()
+        client.send_reset()
 
     stop.set()
     t1.join(timeout=1)
     t2.join(timeout=1)
-    client.close()
     action_sock.close()
     reward_sock.close()
 
@@ -94,13 +93,12 @@ def test_world_model_client_predict_roundtrip():
     t = threading.Thread(target=server, daemon=True)
     t.start()
 
-    client = WorldModelClient(("127.0.0.1", port))
-    obs = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-    pred = client.predict(obs)
+    with WorldModelClient(("127.0.0.1", port)) as client:
+        obs = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        pred = client.predict(obs)
 
     stop.set()
     t.join(timeout=1)
-    client.close()
     sock.close()
 
     assert np.allclose(pred, obs + 2)

--- a/utils/udp_client.py
+++ b/utils/udp_client.py
@@ -19,6 +19,12 @@ class UdpClient:
             self.reward_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.reward_socket.settimeout(timeout)
 
+    def __enter__(self) -> "UdpClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
     def send_action(self, action_idx: int) -> None:
         msg = str(action_idx).encode()
         self.action_socket.sendto(msg, self.action_addr)

--- a/utils/world_model_client.py
+++ b/utils/world_model_client.py
@@ -9,6 +9,12 @@ class WorldModelClient:
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.sock.settimeout(timeout)
 
+    def __enter__(self) -> "WorldModelClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
     def predict(self, obs_sequence: np.ndarray) -> np.ndarray:
         """Send an observation sequence and return the predicted next embedding."""
         self.sock.sendto(obs_sequence.tobytes(), self.addr)


### PR DESCRIPTION
## Summary
- implement `__enter__` and `__exit__` in `UdpClient` and `WorldModelClient`
- use context managers in tests and README examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd6a44fcc832ab0e36606f2bd4010