### PR TITLE
Fix max_steps type

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,7 +35,7 @@ class IntrinsicRewardConfig:
 @dataclass
 class EnvConfig:
     """Default parameters for ``SocketAppEnv``."""
-    max_steps: int = 1e10
+    max_steps: int = int(1e10)
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
     action_dim: int = 7
     state_dim: int = 384


### PR DESCRIPTION
## Summary
- fix `max_steps` in EnvConfig to use an integer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_686bd6a16f9c832a9c72534e277caa7b