### PR TITLE
Refactor intrinsic initialization helper

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -228,6 +228,13 @@ class SocketAppEnv(gym.Env):
         else:
             self.wm_client = None
 
+    def _instantiate_intrinsic(self, cls):
+        """Instantiate ``cls`` with ``latent_dim`` and ``device`` if possible."""
+        try:
+            return cls(latent_dim=self.state_dim, device=self.device)
+        except TypeError:
+            return cls()
+
     def _init_intrinsic(
         self,
         intrinsic_reward: Optional[BaseIntrinsicReward],
@@ -243,19 +250,13 @@ class SocketAppEnv(gym.Env):
             mod_name, cls_name = intrinsic_cls_path.rsplit(".", 1)
             module = importlib.import_module(mod_name)
             cls = getattr(module, cls_name)
-            try:
-                self.intrinsic = cls(latent_dim=self.state_dim, device=self.device)
-            except TypeError:
-                self.intrinsic = cls()
+            self.intrinsic = self._instantiate_intrinsic(cls)
             return
 
         if ir_config is not None:
             module = importlib.import_module(ir_config.module_path)
             cls = getattr(module, ir_config.class_name)
-            try:
-                self.intrinsic = cls(latent_dim=self.state_dim, device=self.device)
-            except TypeError:
-                self.intrinsic = cls()
+            self.intrinsic = self._instantiate_intrinsic(cls)
             return
 
         self.intrinsic = E3BIntrinsicReward(


### PR DESCRIPTION
## Summary
- centralize intrinsic reward instantiation in new `_instantiate_intrinsic`
- use the helper to remove duplication in `_init_intrinsic`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd971a1d0832a85b9bc1fa57b4fd0