### PR TITLE
Add epochs and batch size to PPO update

### DIFF
--- a/tests/test_bandit_env.py
+++ b/tests/test_bandit_env.py
@@ -59,7 +59,19 @@ def test_bandit_env_ppo():
         if buf.ready():
             s_b, a_b, r_b, v_b, lp_b = buf.get()
             returns, adv = compute_gae(r_b, v_b)
-            ppo_update(actor, critic, opt_a, opt_c, s_b, a_b, lp_b, returns, adv)
+            ppo_update(
+                actor,
+                critic,
+                opt_a,
+                opt_c,
+                s_b,
+                a_b,
+                lp_b,
+                returns,
+                adv,
+                num_epochs=2,
+                batch_size=16,
+            )
 
     with torch.no_grad():
         seq = torch.zeros(1, buf.seq_len, state_dim)


### PR DESCRIPTION
## Summary
- expand `ppo_update` to take `num_epochs` and `batch_size`
- allow custom values in `examples/bandit_train.py`
- exercise the new arguments in bandit environment tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd969f9a0832ab1fe1d978dac1229