### PR TITLE
Refactor training entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,9 @@ packages pinned in `requirements.txt`.
    ```
 3. Launch the training script:
    ```bash
-   python main.py
+   python main.py [--sb3] [--timesteps N]
    ```
+   When running without `--sb3`, press **F9** to pause or resume training.
 4. Run a quick random-action demo to inspect rewards:
    ```bash
    python examples/random_agent.py

--- a/main.py
+++ b/main.py
@@ -1,132 +1,30 @@
 import argparse
-import torch
-import torch.nn.functional as F
-import torch.optim as optim
-import torch.distributions as td
-from stable_baselines3 import PPO as SB3PPO
-from stable_baselines3.common.env_util import make_vec_env
-from time import sleep
-import time
-from threading import Thread
-from pynput import keyboard
-from utils import logger
+
 from config import get_config
-
-from envs.socket_env import SocketAppEnv, create_socket_env
-from models.nn import Actor, Q_Critic
-from utils.rollout import RolloutBufferNoDone, compute_gae
-from models.ppo import ppo_update
-
-
-cfg = get_config()
-
-DEVICE = cfg.training.device
-STATE_DIM = cfg.training.state_dim
-ACTION_DIM = cfg.training.action_dim
-SEQ_LEN = cfg.training.seq_len
-
-paused = True
-
-
-def hotkey_listener() -> None:
-    def on_press(key):
-        global paused
-        if key == keyboard.Key.f9:
-            paused = not paused
-            sleep(0.1)
-            print(f"[Pause toggled] Paused = {paused}")
-
-    with keyboard.Listener(on_press=on_press) as listener:
-        listener.join()
+from train import run_training, toggle_pause
+from utils.hotkeys import start_listener
 
 
 def main() -> None:
-    global paused
     parser = argparse.ArgumentParser(description="SocketApp PPO trainer")
-    parser.add_argument("--sb3", action="store_true",default=False,
-                        help="use stable-baselines3 PPO")
-    parser.add_argument("--timesteps", type=int, default=5000,
-                        help="training timesteps for sb3")
+    parser.add_argument(
+        "--sb3",
+        action="store_true",
+        default=False,
+        help="use stable-baselines3 PPO",
+    )
+    parser.add_argument(
+        "--timesteps",
+        type=int,
+        default=5000,
+        help="training timesteps for sb3",
+    )
     args = parser.parse_args()
 
-    if args.sb3:
-        env_fn = lambda: create_socket_env(cfg.env)
-        vec_env = make_vec_env(env_fn, n_envs=1)
-        model = SB3PPO(
-            "MlpPolicy",
-            vec_env,
-            n_steps=cfg.training.rollout_len,
-            batch_size=cfg.training.rollout_len,
-            learning_rate=cfg.training.learning_rate,
-            verbose=1,
-        )
-        model.learn(total_timesteps=args.timesteps)
-        obs = vec_env.reset()
-        action, _ = model.predict(obs, deterministic=True)
-        print("Learned action:", action)
-        vec_env.close()
-        return
-
-    Thread(target=hotkey_listener, daemon=True).start()
-
-    env = create_socket_env(cfg.env)
-    obs, _ = env.reset()
-
-    actor = Actor(state_dim=STATE_DIM, action_dim=ACTION_DIM).to(DEVICE)
-    critic = Q_Critic(shared_lstm=actor.lstm, action_dim=ACTION_DIM).to(DEVICE)
-    optim_actor = optim.Adam(actor.parameters(), lr=cfg.training.learning_rate)
-    optim_critic = optim.Adam(critic.parameters(), lr=cfg.training.learning_rate)
-    buffer = RolloutBufferNoDone(
-        cfg.training.rollout_len,
-        STATE_DIM,
-        ACTION_DIM,
-        "cpu",
-    )
-
-    step_count = 0
-    print("[Started in PAUSED mode] Press F9 to toggle")
-
-    while True:
-        if paused:
-            time.sleep(0.05)
-            continue
-
-        state_tensor = torch.from_numpy(obs).float()
-        emb_seq = buffer.get_latest_state_seq(state_tensor).to(DEVICE)
-
-        logits = actor(emb_seq)
-        dist = td.Categorical(logits=logits.squeeze(0))
-        action = dist.sample()
-        logp = dist.log_prob(action)
-        act_onehot = F.one_hot(action, ACTION_DIM).float()
-
-        obs, reward, terminated, truncated, _ = env.step(action.item())
-        act_onehot = act_onehot.unsqueeze(0)
-        logger.log_scalar("Reward/Total", reward, step_count)
-        action_probs = dist.probs.squeeze(0).detach().cpu().numpy()
-        logger.log_histogram("Action/Probs", action_probs, step_count)
-        logger.log_action_bins("Action/Bins", action_probs, step_count)
-
-        value = critic(emb_seq, act_onehot.to(DEVICE)).squeeze().detach()
-        logp_detached = logp.detach()
-        buffer.add(state_tensor, act_onehot.cpu(), reward, value.cpu(), logp_detached.cpu())
-        if terminated or truncated:
-            obs, _ = env.reset()
-
-        step_count += 1
-        logger.log_scalar("Reward/Total", reward, step_count)
-
-        if buffer.ready() and step_count % cfg.training.update_every == 0:
-            s, a, r, v, lp = buffer.get()
-            returns, adv = compute_gae(r, v)
-            metrics = ppo_update(actor, critic, optim_actor, optim_critic,
-                                 s, a, lp, returns, adv)
-            logger.log_dict({
-                "Loss/Actor": metrics.get("actor_loss", 0.0),
-                "Loss/Critic": metrics.get("critic_loss", 0.0),
-                "KLDiv": metrics.get("kl_div", 0.0),
-            }, step_count)
-            print(f"[PPO Update] Step {step_count}")
+    cfg = get_config()
+    if not args.sb3:
+        start_listener(toggle_pause)
+    run_training(cfg, use_sb3=args.sb3, timesteps=args.timesteps)
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -1,0 +1,114 @@
+import time
+
+import torch
+import torch.nn.functional as F
+import torch.optim as optim
+import torch.distributions as td
+from stable_baselines3 import PPO as SB3PPO
+from stable_baselines3.common.env_util import make_vec_env
+
+from config import Config
+from envs.socket_env import create_socket_env
+from models.nn import Actor, Q_Critic
+from models.ppo import ppo_update
+from utils.rollout import RolloutBufferNoDone, compute_gae
+from utils import logger
+
+
+paused = True
+
+
+def toggle_pause() -> None:
+    """Toggle the global paused flag and print its new state."""
+    global paused
+    paused = not paused
+    print(f"[Pause toggled] Paused = {paused}")
+
+
+def run_training(cfg: Config, use_sb3: bool = False, timesteps: int = 5000) -> None:
+    """Execute PPO training."""
+    global paused
+
+    if use_sb3:
+        env_fn = lambda: create_socket_env(cfg.env)
+        vec_env = make_vec_env(env_fn, n_envs=1)
+        model = SB3PPO(
+            "MlpPolicy",
+            vec_env,
+            n_steps=cfg.training.rollout_len,
+            batch_size=cfg.training.rollout_len,
+            learning_rate=cfg.training.learning_rate,
+            verbose=1,
+        )
+        model.learn(total_timesteps=timesteps)
+        obs = vec_env.reset()
+        action, _ = model.predict(obs, deterministic=True)
+        print("Learned action:", action)
+        vec_env.close()
+        return
+
+    device = cfg.training.device
+    state_dim = cfg.training.state_dim
+    action_dim = cfg.training.action_dim
+
+    env = create_socket_env(cfg.env)
+    obs, _ = env.reset()
+
+    actor = Actor(state_dim=state_dim, action_dim=action_dim).to(device)
+    critic = Q_Critic(shared_lstm=actor.lstm, action_dim=action_dim).to(device)
+    optim_actor = optim.Adam(actor.parameters(), lr=cfg.training.learning_rate)
+    optim_critic = optim.Adam(critic.parameters(), lr=cfg.training.learning_rate)
+    buffer = RolloutBufferNoDone(
+        cfg.training.rollout_len,
+        state_dim,
+        action_dim,
+        "cpu",
+    )
+
+    step_count = 0
+    print("[Started in PAUSED mode] Press F9 to toggle")
+
+    while True:
+        if paused:
+            time.sleep(0.05)
+            continue
+
+        state_tensor = torch.from_numpy(obs).float()
+        emb_seq = buffer.get_latest_state_seq(state_tensor).to(device)
+
+        logits = actor(emb_seq)
+        dist = td.Categorical(logits=logits.squeeze(0))
+        action = dist.sample()
+        logp = dist.log_prob(action)
+        act_onehot = F.one_hot(action, action_dim).float()
+
+        obs, reward, terminated, truncated, _ = env.step(action.item())
+        act_onehot = act_onehot.unsqueeze(0)
+        logger.log_scalar("Reward/Total", reward, step_count)
+        action_probs = dist.probs.squeeze(0).detach().cpu().numpy()
+        logger.log_histogram("Action/Probs", action_probs, step_count)
+        logger.log_action_bins("Action/Bins", action_probs, step_count)
+
+        value = critic(emb_seq, act_onehot.to(device)).squeeze().detach()
+        logp_detached = logp.detach()
+        buffer.add(state_tensor, act_onehot.cpu(), reward, value.cpu(), logp_detached.cpu())
+        if terminated or truncated:
+            obs, _ = env.reset()
+
+        step_count += 1
+        logger.log_scalar("Reward/Total", reward, step_count)
+
+        if buffer.ready() and step_count % cfg.training.update_every == 0:
+            s, a, r, v, lp = buffer.get()
+            returns, adv = compute_gae(r, v)
+            metrics = ppo_update(actor, critic, optim_actor, optim_critic, s, a, lp, returns, adv)
+            logger.log_dict(
+                {
+                    "Loss/Actor": metrics.get("actor_loss", 0.0),
+                    "Loss/Critic": metrics.get("critic_loss", 0.0),
+                    "KLDiv": metrics.get("kl_div", 0.0),
+                },
+                step_count,
+            )
+            print(f"[PPO Update] Step {step_count}")
+

--- a/utils/hotkeys.py
+++ b/utils/hotkeys.py
@@ -1,0 +1,17 @@
+from typing import Callable
+from time import sleep
+from pynput import keyboard
+
+
+def start_listener(toggle: Callable[[], None]) -> keyboard.Listener:
+    """Start an F9 hot-key listener that invokes ``toggle`` when pressed."""
+
+    def on_press(key: keyboard.Key) -> None:
+        if key == keyboard.Key.f9:
+            toggle()
+            sleep(0.1)
+
+    listener = keyboard.Listener(on_press=on_press)
+    listener.daemon = True
+    listener.start()
+    return listener


### PR DESCRIPTION
## Summary
- move F9 hotkey listener into utils
- extract run_training() to train.py
- simplify main.py CLI
- document new CLI flags

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686bde051084832aa1659e1fb196170c