### PR TITLE
Add RewardTracker interface and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ See ``examples/custom_curiosity.py`` for a complete module returning a constant
 bonus.
 
 ## Action and Reward Server
-`servers/action_server.py` exposes `start_combined_udp_server` which wraps
-`ExternalRewardTracker` from `servers/reward_server.py` and processes both
-actions and reward queries on the same UDP port. The server now ignores
-`ConnectionResetError` events so occasional UDP connection resets on Windows do
-not terminate the process. Run this module to start the server.
+`servers/action_server.py` exposes `start_combined_udp_server` which accepts any
+`RewardTracker` implementation. The default tracker is `ExternalRewardTracker`
+from `servers/reward_server.py`. Custom plugins can subclass
+`RewardTracker`—see `examples/constant_tracker.py` for a trivial tracker. The
+server now ignores `ConnectionResetError` events so occasional UDP connection
+resets on Windows do not terminate the process. Run this module to start the
+server.
 
 ## Neural Modules and PPO
 * `models/nn.py` contains LSTM based actor and critic networks.

--- a/examples/constant_tracker.py
+++ b/examples/constant_tracker.py
@@ -1,0 +1,26 @@
+"""Minimal RewardTracker returning a constant value."""
+
+from servers.tracker import RewardTracker
+
+
+class ConstantRewardTracker(RewardTracker):
+    """Tracker that always returns the same reward."""
+
+    def __init__(self, value: float = 1.0):
+        self.value = float(value)
+
+    def compute_reward(self) -> float:
+        return self.value
+
+    def reset(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+if __name__ == "__main__":
+    from servers.reward_server import start_udp_reward_server
+
+    tracker = ConstantRewardTracker(0.5)
+    start_udp_reward_server(tracker)

--- a/servers/action_server.py
+++ b/servers/action_server.py
@@ -2,6 +2,7 @@ import socket
 import time
 from pynput.keyboard import Controller, Key
 from servers.reward_server import ExternalRewardTracker
+from servers.tracker import RewardTracker
 from servers.constants import (
     ARROW_DELAY,
     WAIT_DELAY,
@@ -34,7 +35,7 @@ def send_action(action_idx):
 
 
 # Unified UDP server
-def start_combined_udp_server(tracker, host="0.0.0.0", port=5005):
+def start_combined_udp_server(tracker: RewardTracker, host: str = "0.0.0.0", port: int = 5005) -> None:
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     sock.bind((host, port))
     print(f"[Combined UDP Server] Listening on {host}:{port}")

--- a/servers/reward_server.py
+++ b/servers/reward_server.py
@@ -6,8 +6,10 @@ import psutil
 from pymem import Pymem
 from pymem.exception import MemoryReadError
 
+from servers.tracker import RewardTracker
 
-class ExternalRewardTracker:
+
+class ExternalRewardTracker(RewardTracker):
     def __init__(self, process_id=None, reward_config=None):
         # Auto-find Undertale.exe if no PID provided
         if process_id is None:
@@ -92,7 +94,7 @@ class ExternalRewardTracker:
         self.pm.close_process()
 
 
-def start_udp_reward_server(tracker, host="0.0.0.0", port=5006):
+def start_udp_reward_server(tracker: RewardTracker, host: str = "0.0.0.0", port: int = 5006) -> None:
     """
     UDP server:
       - on 'GET' → replies with '{reward:.6f}'

--- a/servers/tracker.py
+++ b/servers/tracker.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+
+
+class RewardTracker(ABC):
+    """Base interface for extrinsic reward trackers."""
+
+    @abstractmethod
+    def compute_reward(self) -> float:
+        """Return the accumulated extrinsic reward since the last call."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset any internal state used for computing rewards."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def close(self) -> None:
+        """Clean up resources before shutting down."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- create a `RewardTracker` base class for external reward tracking
- refactor `ExternalRewardTracker` to subclass `RewardTracker`
- allow UDP servers to accept any `RewardTracker`
- provide a constant reward tracker example
- document how to plug custom reward trackers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686be0af6848832ababa15a470ec159a