### PR TITLE
Introduce ServerManager for launching servers

### DIFF
--- a/examples/random_agent.py
+++ b/examples/random_agent.py
@@ -1,9 +1,11 @@
 from envs.socket_env import create_socket_env
+from servers.manager import ServerManager
 from config import get_config
 
 def main():
     cfg = get_config()
-    env = create_socket_env(cfg.env)
+    manager = ServerManager() if cfg.env.start_servers else None
+    env = create_socket_env(cfg.env, server_manager=manager)
     obs, _ = env.reset()
     print(f"Initial obs shape: {obs.shape}")
     for step in range(1000):
@@ -16,6 +18,8 @@ def main():
         if terminated or truncated:
             break
     env.close()
+    if manager is not None:
+        manager.stop()
 
 
 if __name__ == "__main__":

--- a/servers/manager.py
+++ b/servers/manager.py
@@ -1,0 +1,55 @@
+import socket
+import subprocess
+import sys
+from typing import List
+
+
+class ServerManager:
+    """Launch and stop reward/action/world model servers."""
+
+    def __init__(self) -> None:
+        self._processes: List[subprocess.Popen] = []
+
+    def _port_in_use(self, addr) -> bool:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            sock.bind(addr)
+        except OSError:
+            sock.close()
+            return True
+        sock.close()
+        return False
+
+    def start(self, env) -> None:
+        """Start servers for ``env`` if their ports are free."""
+        if env.combined_server:
+            if not self._port_in_use(env.action_addr):
+                cmd = [sys.executable, '-m', 'servers.action_server']
+                p = subprocess.Popen(cmd)
+                self._processes.append(p)
+        else:
+            if not self._port_in_use(env.reward_addr):
+                cmd = [sys.executable, '-m', 'servers.reward_server']
+                p = subprocess.Popen(cmd)
+                self._processes.append(p)
+
+        if env.use_world_model and not self._port_in_use(env.wm_addr):
+            cmd = [
+                sys.executable, '-m', 'servers.world_model_server',
+                '--model-path', env.world_model_path,
+                '--model-type', env.world_model_type,
+                '--host', env.wm_addr[0],
+                '--port', str(env.wm_addr[1])
+            ]
+            p = subprocess.Popen(cmd)
+            self._processes.append(p)
+
+    def stop(self) -> None:
+        """Terminate all started server processes."""
+        for proc in self._processes:
+            proc.terminate()
+            try:
+                proc.wait(timeout=1)
+            except Exception:
+                pass
+        self._processes.clear()


### PR DESCRIPTION
## Summary
- move server launching code into `ServerManager`
- allow `SocketAppEnv` to use an optional server manager
- propagate server manager via `create_socket_env` and training scripts
- ensure envs don't spawn servers when `start_servers=False`
- update examples and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be0900620832aba20d765b5192f55