### PR TITLE
Fix stray function definition in servers

### DIFF
--- a/servers/action_server.py
+++ b/servers/action_server.py
@@ -37,11 +37,6 @@ def send_action(action_idx):
 
 # Unified UDP server
 
-def start_combined_udp_server(tracker: RewardTracker, host: str = "0.0.0.0", port: int = 5005) -> None:
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind((host, port))
-    print(f"[Combined UDP Server] Listening on {host}:{port}")
-
 def start_combined_udp_server(tracker, host="0.0.0.0", port=5005):
     """Start a UDP server processing actions and reward commands."""
 


### PR DESCRIPTION
## Summary
- remove leftover socket-based start function
- keep single `start_combined_udp_server` implementation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be6badd48832a9cf504c044a54b81