### PR TITLE
Refactor UDP servers to subclass base and update env

### DIFF
--- a/servers/__init__.py
+++ b/servers/__init__.py
@@ -1,0 +1,17 @@
+"""Server utilities and reward tracker registry."""
+
+from .base import UdpServer
+from .reward_server import ExternalRewardTracker
+
+try:
+    from examples.constant_tracker import ConstantRewardTracker
+except Exception:  # pragma: no cover - optional example module
+    ConstantRewardTracker = None
+
+
+REWARD_TRACKERS = {"external": ExternalRewardTracker}
+if ConstantRewardTracker is not None:
+    REWARD_TRACKERS["constant"] = ConstantRewardTracker
+
+__all__ = ["UdpServer", "REWARD_TRACKERS", "ExternalRewardTracker"]
+


### PR DESCRIPTION
## Summary
- expand `UdpServer` with `serve()` and shutdown support
- refactor action, reward and world model servers to subclasses
- maintain helper functions for backward compatibility
- register available reward trackers in `servers.__init__`
- allow `SocketAppEnv` to launch a custom server class or factory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686be9c9a214832ab8481edc4acb97e0