### PR TITLE
Refactor intrinsic reward interface

### DIFF
--- a/utils/curiosity_base.py
+++ b/utils/curiosity_base.py
@@ -1,25 +1,14 @@
-from typing import Protocol
+from abc import ABC, abstractmethod
 import numpy as np
 import gymnasium as gym
 
+class IntrinsicReward(ABC):
+    """Abstract base class for intrinsic reward modules."""
 
-class IntrinsicReward(Protocol):
-    """Protocol for intrinsic reward modules."""
-
+    @abstractmethod
     def reset(self) -> None:
         """Reset the internal state if any."""
 
+    @abstractmethod
     def compute(self, observation: np.ndarray, env: gym.Env) -> float:
         """Return intrinsic reward for an observation in the given environment."""
-
-
-class CuriosityReward:
-    """Interface for intrinsic reward modules."""
-
-    def reset(self) -> None:  # pragma: no cover - interface
-        """Reset the internal state if any."""
-        raise NotImplementedError
-
-    def compute(self, obs, env):  # pragma: no cover - interface
-        """Return intrinsic reward for observation in the given environment."""
-        raise NotImplementedError

--- a/utils/intrinsic.py
+++ b/utils/intrinsic.py
@@ -1,19 +1,9 @@
 import torch
-from abc import ABC, abstractmethod
-
-from .curiosity_base import CuriosityReward, IntrinsicReward
+from .curiosity_base import IntrinsicReward
 
 
-class BaseIntrinsicReward(CuriosityReward, IntrinsicReward, ABC):
+class BaseIntrinsicReward(IntrinsicReward):
     """Abstract base class for intrinsic reward modules."""
-
-    @abstractmethod
-    def reset(self) -> None:
-        """Reset the internal state if any."""
-
-    @abstractmethod
-    def compute(self, observation, env=None) -> float:
-        """Return the intrinsic reward for an observation."""
 
 class E3BIntrinsicReward(BaseIntrinsicReward):
     def __init__(self, latent_dim=384, decay=0.9995, ridge=0.1, device="cpu"):


### PR DESCRIPTION
## Summary
- remove CuriosityReward and turn IntrinsicReward into an abstract base class
- simplify BaseIntrinsicReward to inherit only from IntrinsicReward

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bf2366828832aa806516c0938c17d