### PR TITLE
Update intrinsic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository implements a reinforcement learning setup that interacts with an
 
 ## Custom Curiosity Modules
 The environment can dynamically load a curiosity plugin via the
-``EnvConfig.intrinsic_cls`` setting. Each plugin must implement the
+``EnvConfig.intrinsic_name`` setting. Each plugin must implement the
 ``BaseIntrinsicReward`` interface which defines ``reset()`` and ``compute(obs, env)``.
 
 Minimal example implementing a constant bonus:
@@ -55,7 +55,7 @@ env = SocketAppEnv(intrinsic_reward=MyReward(), start_servers=False)
 # Or via configuration
 from config import get_config
 cfg = get_config()
-cfg.env.intrinsic_cls = "examples.custom_curiosity.MyReward"
+cfg.env.intrinsic_name = "examples.custom_curiosity.MyReward"
 env = SocketAppEnv(config=cfg.env, start_servers=False)
 ```
 

--- a/config.py
+++ b/config.py
@@ -27,12 +27,6 @@ class WorldModelConfig:
 
 
 @dataclass
-class IntrinsicRewardConfig:
-    """Location of the curiosity reward module."""
-    module_path: str = "utils.intrinsic"
-    class_name: str = "E3BIntrinsicReward"
-
-@dataclass
 class EnvConfig:
     """Default parameters for ``SocketAppEnv``."""
     max_steps: int = int(1e10)
@@ -49,8 +43,7 @@ class EnvConfig:
     enable_logging: bool = True
     use_world_model: bool = True
     world_model: WorldModelConfig = field(default_factory=WorldModelConfig)
-    intrinsic_reward: IntrinsicRewardConfig = field(default_factory=IntrinsicRewardConfig)
-    intrinsic_cls: str = "utils.intrinsic.E3BIntrinsicReward"
+    intrinsic_name: str = "E3BIntrinsicReward"
 
 
 @dataclass

--- a/tests/test_socket_env.py
+++ b/tests/test_socket_env.py
@@ -126,7 +126,7 @@ def test_socket_env_config_intrinsic():
     obs_enc = DummyObsEncoder()
     from config import get_config
     cfg = get_config()
-    cfg.env.intrinsic_cls = "examples.custom_curiosity.ConstantCuriosity"
+    cfg.env.intrinsic_name = "examples.custom_curiosity.ConstantCuriosity"
     env = SocketAppEnv(
         max_steps=1,
         device="cpu",


### PR DESCRIPTION
## Summary
- consolidate intrinsic plugin settings into `intrinsic_name`
- simplify intrinsic initialization in `SocketAppEnv`
- document the new config field
- update tests for renamed option

## Testing
- `python -m py_compile config.py envs/socket_env.py tests/test_socket_env.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_686c57cb82a0832a89bff976735cd062