### PR TITLE
Add intrinsic reward registry and composite reward

### DIFF
--- a/envs/socket_env.py
+++ b/envs/socket_env.py
@@ -255,9 +255,12 @@ class SocketAppEnv(gym.Env):
 
         cls = None
         if intrinsic_name is not None:
-            from utils.intrinsic_registry import INTRINSIC_REWARDS
+            from utils.intrinsic_registry import get_reward
 
-            cls = INTRINSIC_REWARDS.get(intrinsic_name)
+            try:
+                cls = get_reward(intrinsic_name)
+            except KeyError:
+                cls = None
             if cls is not None:
                 self.intrinsic = self._instantiate_intrinsic(cls)
                 return

--- a/tests/test_intrinsic_registry.py
+++ b/tests/test_intrinsic_registry.py
@@ -1,0 +1,118 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import numpy as np
+import pytest
+
+try:
+    from envs.socket_env import SocketAppEnv
+    from utils.intrinsic import BaseIntrinsicReward
+except ModuleNotFoundError:
+    SocketAppEnv = None
+    class BaseIntrinsicReward:
+        def reset(self):
+            pass
+        def compute(self, obs, env):
+            return 0.0
+
+from utils.intrinsic_registry import register_reward, get_reward, CompositeIntrinsicReward
+
+
+class DummyUdpClient:
+    def __init__(self, reward: float = 1.0):
+        self.reward = reward
+        self.actions = []
+
+    def send_action(self, action_idx: int) -> None:
+        self.actions.append(action_idx)
+
+    def send_reset(self) -> None:
+        pass
+
+    def get_reward(self) -> float:
+        return self.reward
+
+    def close(self) -> None:
+        pass
+
+
+class DummyObsEncoder:
+    def __init__(self, dim: int = 384):
+        self.dim = dim
+
+    def get_embedding(self) -> np.ndarray:
+        return np.zeros(self.dim, dtype=np.float32)
+
+    def close(self):
+        pass
+
+
+def test_register_and_get_reward():
+    class MyReward(BaseIntrinsicReward):
+        def reset(self):
+            pass
+        def compute(self, obs, env):
+            return 2.5
+
+    register_reward("MyReward", MyReward)
+    assert get_reward("MyReward") is MyReward
+
+
+def test_env_builds_reward_from_registry():
+    if SocketAppEnv is None:
+        pytest.skip("gymnasium not installed")
+
+    class RegReward(BaseIntrinsicReward):
+        def reset(self):
+            pass
+        def compute(self, obs, env):
+            return 3.0
+
+    register_reward("RegReward", RegReward)
+
+    udp = DummyUdpClient(reward=1.0)
+    obs_enc = DummyObsEncoder()
+    env = SocketAppEnv(
+        max_steps=1,
+        device="cpu",
+        embedding_model=None,
+        combined_server=False,
+        enable_logging=False,
+        start_servers=False,
+        use_world_model=False,
+        udp_client=udp,
+        obs_encoder=obs_enc,
+        server_manager=None,
+        config=None,
+        intrinsic_reward=None,
+        intrinsic_name="RegReward",
+    )
+    env.reset()
+    _, reward, _, _, info = env.step(0)
+    assert info["intrinsic"] == 3.0
+    env.close()
+
+
+def test_composite_intrinsic_reward():
+    class R1(BaseIntrinsicReward):
+        def reset(self):
+            pass
+        def compute(self, obs, env):
+            return 1.0
+
+    class R2(BaseIntrinsicReward):
+        def reset(self):
+            pass
+        def compute(self, obs, env):
+            return 2.0
+
+    register_reward("R1", R1)
+    register_reward("R2", R2)
+
+    comp = CompositeIntrinsicReward(["R1", "R2"], latent_dim=1, device="cpu")
+    comp.reset()
+    val = comp.compute(np.zeros(1, dtype=np.float32), None)
+    assert val == 3.0

--- a/utils/intrinsic_registry.py
+++ b/utils/intrinsic_registry.py
@@ -1,24 +1,55 @@
-from typing import Dict, Type
+from typing import Dict, Type, List
 
 from .intrinsic import BaseIntrinsicReward, E3BIntrinsicReward
 
+# Registry mapping names to intrinsic reward classes
 INTRINSIC_REWARDS: Dict[str, Type[BaseIntrinsicReward]] = {}
 
 
-def register_intrinsic(name: str, cls: Type[BaseIntrinsicReward]) -> None:
-    """Register an intrinsic reward class by name."""
+def register_reward(name: str, cls: Type[BaseIntrinsicReward]) -> None:
+    """Register an intrinsic reward class under ``name``."""
     INTRINSIC_REWARDS[name] = cls
 
 
-def get_intrinsic(name: str) -> Type[BaseIntrinsicReward]:
-    """Retrieve a registered intrinsic reward class."""
+# Backwards compatibility
+register_intrinsic = register_reward
+
+
+def get_reward(name: str) -> Type[BaseIntrinsicReward]:
+    """Retrieve a registered intrinsic reward class by ``name``."""
     if name not in INTRINSIC_REWARDS:
         raise KeyError(f"Unknown intrinsic reward: {name}")
     return INTRINSIC_REWARDS[name]
 
 
+# Backwards compatibility
+get_intrinsic = get_reward
+
+
+class CompositeIntrinsicReward(BaseIntrinsicReward):
+    """Combine multiple intrinsic rewards by summing their outputs."""
+
+    def __init__(self, reward_names: List[str], latent_dim: int = 384, device: str = "cpu"):
+        self.modules: List[BaseIntrinsicReward] = []
+        for n in reward_names:
+            cls = get_reward(n)
+            try:
+                inst = cls(latent_dim=latent_dim, device=device)
+            except TypeError:
+                inst = cls()
+            self.modules.append(inst)
+
+    def reset(self) -> None:
+        for m in self.modules:
+            m.reset()
+
+    def compute(self, observation, env) -> float:
+        return float(sum(m.compute(observation, env) for m in self.modules))
+
+
 # Built-in registrations
 register_intrinsic("E3BIntrinsicReward", E3BIntrinsicReward)
+register_intrinsic("CompositeIntrinsicReward", CompositeIntrinsicReward)
 
 # Optionally register example curiosity modules
 try:


### PR DESCRIPTION
## Summary
- implement `register_reward`/`get_reward` and `CompositeIntrinsicReward`
- allow `SocketAppEnv` to build intrinsic rewards through the registry
- test registering, instantiating and combining intrinsic rewards

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c62efbc00832aa5d853f99756a54a