### PR TITLE
Add multiple intrinsic rewards support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ This repository implements a reinforcement learning setup that interacts with an
 * Extrinsic and intrinsic rewards are summed for each step.
 
 ## Custom Curiosity Modules
-The environment can dynamically load a curiosity plugin via the
-``EnvConfig.intrinsic_name`` setting. Each plugin must implement the
+The environment can dynamically load one or more curiosity plugins via the
+``EnvConfig.intrinsic_names`` setting. Each plugin must implement the
 ``BaseIntrinsicReward`` interface which defines ``reset()`` and ``compute(obs, env)``.
 
 Minimal example implementing a constant bonus:
@@ -55,8 +55,17 @@ env = SocketAppEnv(intrinsic_reward=MyReward(), start_servers=False)
 # Or via configuration
 from config import get_config
 cfg = get_config()
-cfg.env.intrinsic_name = "examples.custom_curiosity.MyReward"
+cfg.env.intrinsic_names = ["examples.custom_curiosity.MyReward"]
 env = SocketAppEnv(config=cfg.env, start_servers=False)
+```
+
+To combine multiple rewards simply list several names:
+
+```python
+cfg.env.intrinsic_names = [
+    "examples.custom_curiosity.MyReward",
+    "E3BIntrinsicReward",
+]
 ```
 
 See ``examples/custom_curiosity.py`` for a complete module returning a constant

--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@
 # Contains all tunable parameters used across modules.
 
 from dataclasses import dataclass, field
-from typing import Dict, Set
+from typing import Dict, Set, List
 import torch
 
 
@@ -43,7 +43,7 @@ class EnvConfig:
     enable_logging: bool = True
     use_world_model: bool = True
     world_model: WorldModelConfig = field(default_factory=WorldModelConfig)
-    intrinsic_name: str = "E3BIntrinsicReward"
+    intrinsic_names: list[str] = field(default_factory=lambda: ["E3BIntrinsicReward"])
 
 
 @dataclass

--- a/tests/test_intrinsic_registry.py
+++ b/tests/test_intrinsic_registry.py
@@ -88,7 +88,7 @@ def test_env_builds_reward_from_registry():
         server_manager=None,
         config=None,
         intrinsic_reward=None,
-        intrinsic_name="RegReward",
+        intrinsic_names=["RegReward"],
     )
     env.reset()
     _, reward, _, _, info = env.step(0)

--- a/tests/test_socket_env.py
+++ b/tests/test_socket_env.py
@@ -126,7 +126,7 @@ def test_socket_env_config_intrinsic():
     obs_enc = DummyObsEncoder()
     from config import get_config
     cfg = get_config()
-    cfg.env.intrinsic_name = "examples.custom_curiosity.ConstantCuriosity"
+    cfg.env.intrinsic_names = ["examples.custom_curiosity.ConstantCuriosity"]
     env = SocketAppEnv(
         max_steps=1,
         device="cpu",

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,1 +1,7 @@
-from . import logger
+"""Utility helpers for logging and other features."""
+
+try:
+    from . import logger  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    logger = None
+


### PR DESCRIPTION
## Summary
- introduce intrinsic reward lists via `EnvConfig.intrinsic_names`
- update `SocketAppEnv` to handle multiple intrinsic modules
- make utils optional-import of logger
- document combining rewards in README
- adjust tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c76096ad8832a91f02a5a0c76fde0