### PR TITLE
Add remote intrinsic reward server

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ understands the `GET` and `RESET` commands and replies with the computed reward
 or ``OK`` respectively.  Run ``python -m servers.action_server`` to launch the
 combined server.
 
+`servers/intrinsic_server.py` exposes `start_udp_intrinsic_server` which hosts a
+single curiosity module over UDP. Pass `--name` with any registered reward class
+to run it as a standalone process.
+
 `servers/action_server.py` exposes `start_combined_udp_server` which accepts any
 `RewardTracker` implementation. The default tracker is `ExternalRewardTracker`
 from `servers/reward_server.py`. Custom plugins can subclass
@@ -121,15 +125,20 @@ packages pinned in `requirements.txt`.
    the world model server, which in turn divides its predictions by ten
    before replying.
 
+ ```bash
+  python servers/world_model_server.py
+  ```
+3. (Optional) start the intrinsic reward server to offload curiosity
+   computation:
    ```bash
-   python servers/world_model_server.py
+   python -m servers.intrinsic_server --name E3BIntrinsicReward
    ```
-3. Launch the training script:
+4. Launch the training script:
    ```bash
    python main.py [--sb3] [--timesteps N]
    ```
    When running without `--sb3`, press **F9** to pause or resume training.
-4. Run a quick random-action demo to inspect rewards:
+5. Run a quick random-action demo to inspect rewards:
    ```bash
    python examples/random_agent.py
    ```

--- a/config.py
+++ b/config.py
@@ -27,6 +27,14 @@ class WorldModelConfig:
 
 
 @dataclass
+class IntrinsicServerConfig:
+    """Settings for the optional intrinsic reward server."""
+    host: str = "127.0.0.1"
+    port: int = 5008
+    reward_name: str = "E3BIntrinsicReward"
+
+
+@dataclass
 class EnvConfig:
     """Default parameters for ``SocketAppEnv``."""
     max_steps: int = int(1e10)
@@ -42,7 +50,9 @@ class EnvConfig:
     start_servers: bool = True
     enable_logging: bool = True
     use_world_model: bool = True
+    use_intrinsic_server: bool = False
     world_model: WorldModelConfig = field(default_factory=WorldModelConfig)
+    intrinsic_server: IntrinsicServerConfig = field(default_factory=IntrinsicServerConfig)
     intrinsic_names: list[str] = field(default_factory=lambda: ["E3BIntrinsicReward"])
 
 

--- a/servers/__init__.py
+++ b/servers/__init__.py
@@ -2,6 +2,7 @@
 
 from .base import UdpServer
 from .reward_server import ExternalRewardTracker
+from .intrinsic_server import IntrinsicServer, start_udp_intrinsic_server
 
 try:
     from examples.constant_tracker import ConstantRewardTracker
@@ -13,5 +14,11 @@ REWARD_TRACKERS = {"external": ExternalRewardTracker}
 if ConstantRewardTracker is not None:
     REWARD_TRACKERS["constant"] = ConstantRewardTracker
 
-__all__ = ["UdpServer", "REWARD_TRACKERS", "ExternalRewardTracker"]
+__all__ = [
+    "UdpServer",
+    "REWARD_TRACKERS",
+    "ExternalRewardTracker",
+    "IntrinsicServer",
+    "start_udp_intrinsic_server",
+]
 

--- a/servers/intrinsic_server.py
+++ b/servers/intrinsic_server.py
@@ -1,0 +1,58 @@
+import numpy as np
+from utils.intrinsic_registry import get_reward
+from .base import UdpServer
+
+
+class IntrinsicServer(UdpServer):
+    """UDP server wrapping an intrinsic reward module."""
+
+    def __init__(self, reward_name: str, host: str = "0.0.0.0", port: int = 5008,
+                 latent_dim: int = 384, device: str = "cpu"):
+        self.reward_name = reward_name
+        cls = get_reward(reward_name)
+        try:
+            self.reward = cls(latent_dim=latent_dim, device=device)
+        except TypeError:
+            self.reward = cls()
+        super().__init__(host, port)
+
+    def handle(self, data: bytes, addr):
+        if data == b"RESET":
+            self.reward.reset()
+            return b"OK"
+        if data == b"PING":
+            return b"PONG"
+        obs = np.frombuffer(data, dtype=np.float32)
+        val = self.reward.compute(obs, None)
+        return f"{float(val):.6f}"
+
+
+def start_udp_intrinsic_server(reward_name: str, host: str = "0.0.0.0",
+                               port: int = 5008, latent_dim: int = 384,
+                               device: str = "cpu") -> None:
+    """Convenience helper for ``IntrinsicServer``."""
+    server = IntrinsicServer(reward_name, host=host, port=port,
+                             latent_dim=latent_dim, device=device)
+    server.serve()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Start the UDP intrinsic reward server.")
+    parser.add_argument("--name", default="E3BIntrinsicReward",
+                        help="Registered reward class name")
+    parser.add_argument("--host", default="0.0.0.0", help="Interface to bind")
+    parser.add_argument("--port", type=int, default=5008, help="UDP port to listen on")
+    parser.add_argument("--latent-dim", type=int, default=384,
+                        help="Embedding dimension")
+    parser.add_argument("--device", default="cpu", help="Torch device")
+    args = parser.parse_args()
+
+    start_udp_intrinsic_server(
+        reward_name=args.name,
+        host=args.host,
+        port=args.port,
+        latent_dim=args.latent_dim,
+        device=args.device,
+    )

--- a/servers/manager.py
+++ b/servers/manager.py
@@ -44,6 +44,18 @@ class ServerManager:
             p = subprocess.Popen(cmd)
             self._processes.append(p)
 
+        if env.use_intrinsic_server and not self._port_in_use(env.intrinsic_addr):
+            cmd = [
+                sys.executable, '-m', 'servers.intrinsic_server',
+                '--name', env.intrinsic_reward_name,
+                '--host', env.intrinsic_addr[0],
+                '--port', str(env.intrinsic_addr[1]),
+                '--latent-dim', str(env.state_dim),
+                '--device', env.device,
+            ]
+            p = subprocess.Popen(cmd)
+            self._processes.append(p)
+
     def stop(self) -> None:
         """Terminate all started server processes."""
         for proc in self._processes:

--- a/tests/test_intrinsic_server.py
+++ b/tests/test_intrinsic_server.py
@@ -1,0 +1,44 @@
+import threading
+import socket
+import numpy as np
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+import sys
+sys.path.insert(0, str(ROOT))
+
+from servers.intrinsic_server import IntrinsicServer
+from tests.utils import get_free_udp_port
+
+
+def test_intrinsic_server_compute_and_reset():
+    port = get_free_udp_port()
+    server = IntrinsicServer(
+        'examples.custom_curiosity.ConstantCuriosity',
+        host='127.0.0.1',
+        port=port,
+        latent_dim=4,
+        device='cpu'
+    )
+    t = threading.Thread(target=server.serve, daemon=True)
+    t.start()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(0.5)
+    addr = ('127.0.0.1', port)
+    try:
+        arr = np.zeros(4, dtype=np.float32)
+        sock.sendto(arr.tobytes(), addr)
+        data, _ = sock.recvfrom(64)
+        val = float(data.decode())
+        assert val == 1.0
+        sock.sendto(b'RESET', addr)
+        data, _ = sock.recvfrom(64)
+        assert data == b'OK'
+    finally:
+        server.shutdown()
+        t.join(timeout=1)
+        sock.close()
+
+

--- a/utils/intrinsic_client.py
+++ b/utils/intrinsic_client.py
@@ -1,0 +1,33 @@
+import socket
+from typing import Tuple
+import numpy as np
+
+
+class IntrinsicClient:
+    """UDP client for an intrinsic reward server."""
+
+    def __init__(self, addr: Tuple[str, int], timeout: float = 0.2):
+        self.addr = addr
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.settimeout(timeout)
+
+    def __enter__(self) -> "IntrinsicClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def compute(self, obs: np.ndarray) -> float:
+        self.sock.sendto(obs.astype(np.float32).tobytes(), self.addr)
+        data, _ = self.sock.recvfrom(64)
+        return float(data.decode().strip())
+
+    def send_reset(self) -> None:
+        try:
+            self.sock.sendto(b"RESET", self.addr)
+            self.sock.recvfrom(32)
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        self.sock.close()


### PR DESCRIPTION
## Summary
- implement IntrinsicServer and helper to run UDP intrinsic reward modules
- add IntrinsicClient and integrate into `SocketAppEnv`
- start the new server from `ServerManager`
- expose server in package
- document usage in README
- add tests for IntrinsicServer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch' ...)*

------
https://chatgpt.com/codex/tasks/task_e_686cb00611f8832a82359e49d7e17280