### PR TITLE
Add ICM intrinsic reward module and UDP server

### DIFF
--- a/intrinsic_servers/base.py
+++ b/intrinsic_servers/base.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+import numpy as np
+from servers.base import UdpServer
+
+
+@dataclass
+class IntrinsicInput:
+    observation: np.ndarray
+    action: Optional[int] = None
+    step_id: Optional[int] = None
+    env_time: Optional[float] = None
+    done: Optional[bool] = False
+
+
+class BaseUDPIntrinsicServer(UdpServer):
+    """Base class for UDP intrinsic reward servers."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 0, *, latent_dim: int = 384, device: str = "cpu"):
+        self.latent_dim = latent_dim
+        self.device = device
+        super().__init__(host, port)
+
+    # ------------------------------------------------------------------
+    # Methods to override
+    # ------------------------------------------------------------------
+    def compute(self, inp: IntrinsicInput) -> float:
+        raise NotImplementedError
+
+    def reset(self) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # UDP handler
+    # ------------------------------------------------------------------
+    def handle(self, data: bytes, addr):
+        if data == b"RESET":
+            self.reset()
+            return b"OK"
+        if data == b"PING":
+            return b"PONG"
+        obs = np.frombuffer(data, dtype=np.float32)
+        inp = IntrinsicInput(observation=obs)
+        val = float(self.compute(inp))
+        return f"{val:.6f}"

--- a/intrinsic_servers/e3m_server.py
+++ b/intrinsic_servers/e3m_server.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+import numpy as np
+from utils.intrinsic import E3BIntrinsicReward
+from .base import BaseUDPIntrinsicServer, IntrinsicInput
+from .registry import register
+
+
+@register("e3b")
+class E3MServer(BaseUDPIntrinsicServer):
+    """Intrinsic server wrapping :class:`E3BIntrinsicReward`."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 5008, *, latent_dim: int = 384, device: str = "cpu"):
+        self.module = E3BIntrinsicReward(latent_dim=latent_dim, device=device)
+        super().__init__(host, port, latent_dim=latent_dim, device=device)
+
+    def reset(self) -> None:
+        self.module.reset()
+
+    def compute(self, inp: IntrinsicInput) -> float:
+        return float(self.module.compute(np.asarray(inp.observation), None))

--- a/intrinsic_servers/icm_server.py
+++ b/intrinsic_servers/icm_server.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import numpy as np
+from utils.icm import ICMIntrinsicReward
+from .base import BaseUDPIntrinsicServer, IntrinsicInput
+from .registry import register
+
+
+@register("icm")
+class ICMServer(BaseUDPIntrinsicServer):
+    """UDP server providing ICM intrinsic rewards."""
+
+    def __init__(self, host: str = "0.0.0.0", port: int = 5009, *, latent_dim: int = 384, action_dim: int = 7, device: str = "cpu"):
+        self.module = ICMIntrinsicReward(obs_dim=latent_dim, action_dim=action_dim, device=device)
+        self.action_dim = action_dim
+        self._prev_obs: np.ndarray | None = None
+        self._prev_action: int | None = None
+        super().__init__(host, port, latent_dim=latent_dim, device=device)
+
+    def reset(self) -> None:
+        self.module.reset()
+        self._prev_obs = None
+        self._prev_action = None
+
+    def handle(self, data: bytes, addr):
+        if data == b"RESET":
+            self.reset()
+            return b"OK"
+        if data == b"PING":
+            return b"PONG"
+        arr = np.frombuffer(data, dtype=np.float32)
+        if arr.size != self.latent_dim + 1:
+            return b"ERR"
+        action = int(arr[0])
+        obs = arr[1:]
+        inp = IntrinsicInput(observation=obs, action=action)
+        val = float(self.compute(inp))
+        return f"{val:.6f}"
+
+    def compute(self, inp: IntrinsicInput) -> float:
+        obs = np.asarray(inp.observation)
+        action = int(inp.action if inp.action is not None else 0)
+        if self._prev_obs is None:
+            self._prev_obs = obs
+            self._prev_action = action
+            return 0.0
+        reward = self.module.compute_pair(self._prev_obs, obs, action)
+        self._prev_obs = obs
+        self._prev_action = action
+        return float(reward)
+

--- a/intrinsic_servers/orchestrator.py
+++ b/intrinsic_servers/orchestrator.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from typing import Iterable, Tuple
+
+from .base import BaseUDPIntrinsicServer, IntrinsicInput
+
+
+class IntrinsicRewardOrchestrator:
+    """Combine multiple intrinsic servers with optional weights."""
+
+    def __init__(self, modules: Iterable[Tuple[BaseUDPIntrinsicServer, float]]):
+        self.modules = list(modules)
+
+    def compute_all(self, inp: IntrinsicInput) -> float:
+        total = 0.0
+        for module, weight in self.modules:
+            total += module.compute(inp) * weight
+        return float(total)

--- a/intrinsic_servers/registry.py
+++ b/intrinsic_servers/registry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+from typing import Callable, Dict, Type
+
+from .base import BaseUDPIntrinsicServer
+
+# Registry mapping names to server classes
+INTRINSIC_SERVER_REGISTRY: Dict[str, Type[BaseUDPIntrinsicServer]] = {}
+
+
+def register(name: str) -> Callable[[Type[BaseUDPIntrinsicServer]], Type[BaseUDPIntrinsicServer]]:
+    def wrapper(cls: Type[BaseUDPIntrinsicServer]) -> Type[BaseUDPIntrinsicServer]:
+        INTRINSIC_SERVER_REGISTRY[name] = cls
+        return cls
+    return wrapper
+
+
+def get_server(name: str) -> Type[BaseUDPIntrinsicServer]:
+    if name not in INTRINSIC_SERVER_REGISTRY:
+        raise KeyError(f"Unknown intrinsic server: {name}")
+    return INTRINSIC_SERVER_REGISTRY[name]

--- a/servers/intrinsic_server.py
+++ b/servers/intrinsic_server.py
@@ -1,38 +1,42 @@
+from __future__ import annotations
+import importlib
 import numpy as np
 from utils.intrinsic_registry import get_reward
-from .base import UdpServer
+from intrinsic_servers.base import BaseUDPIntrinsicServer, IntrinsicInput
 
 
-class IntrinsicServer(UdpServer):
+class IntrinsicServer(BaseUDPIntrinsicServer):
     """UDP server wrapping an intrinsic reward module."""
 
-    def __init__(self, reward_name: str, host: str = "0.0.0.0", port: int = 5008,
-                 latent_dim: int = 384, device: str = "cpu"):
+    def __init__(self, reward_name: str, host: str = "0.0.0.0", port: int = 5008, latent_dim: int = 384, device: str = "cpu"):
         self.reward_name = reward_name
-        cls = get_reward(reward_name)
+        cls = None
+        try:
+            cls = get_reward(reward_name)
+        except KeyError:
+            if "." in reward_name:
+                mod_name, cls_name = reward_name.rsplit(".", 1)
+                module = importlib.import_module(mod_name)
+                cls = getattr(module, cls_name)
+            else:
+                raise
         try:
             self.reward = cls(latent_dim=latent_dim, device=device)
         except TypeError:
             self.reward = cls()
-        super().__init__(host, port)
+        super().__init__(host, port, latent_dim=latent_dim, device=device)
 
-    def handle(self, data: bytes, addr):
-        if data == b"RESET":
+    def reset(self) -> None:
+        if hasattr(self.reward, "reset"):
             self.reward.reset()
-            return b"OK"
-        if data == b"PING":
-            return b"PONG"
-        obs = np.frombuffer(data, dtype=np.float32)
-        val = self.reward.compute(obs, None)
-        return f"{float(val):.6f}"
+
+    def compute(self, inp: IntrinsicInput) -> float:
+        return float(self.reward.compute(np.asarray(inp.observation), None))
 
 
-def start_udp_intrinsic_server(reward_name: str, host: str = "0.0.0.0",
-                               port: int = 5008, latent_dim: int = 384,
-                               device: str = "cpu") -> None:
+def start_udp_intrinsic_server(reward_name: str, host: str = "0.0.0.0", port: int = 5008, latent_dim: int = 384, device: str = "cpu") -> None:
     """Convenience helper for ``IntrinsicServer``."""
-    server = IntrinsicServer(reward_name, host=host, port=port,
-                             latent_dim=latent_dim, device=device)
+    server = IntrinsicServer(reward_name, host=host, port=port, latent_dim=latent_dim, device=device)
     server.serve()
 
 
@@ -40,12 +44,10 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="Start the UDP intrinsic reward server.")
-    parser.add_argument("--name", default="E3BIntrinsicReward",
-                        help="Registered reward class name")
+    parser.add_argument("--name", default="E3BIntrinsicReward", help="Registered reward class name or module path")
     parser.add_argument("--host", default="0.0.0.0", help="Interface to bind")
     parser.add_argument("--port", type=int, default=5008, help="UDP port to listen on")
-    parser.add_argument("--latent-dim", type=int, default=384,
-                        help="Embedding dimension")
+    parser.add_argument("--latent-dim", type=int, default=384, help="Embedding dimension")
     parser.add_argument("--device", default="cpu", help="Torch device")
     args = parser.parse_args()
 

--- a/tests/test_icm_reward.py
+++ b/tests/test_icm_reward.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+try:
+    from utils.icm import ICMIntrinsicReward
+except Exception:  # pragma: no cover - torch missing
+    ICMIntrinsicReward = None
+
+
+class DummyEnv:
+    def __init__(self):
+        self.last_action = None
+
+
+def test_icm_basic_prediction():
+    if ICMIntrinsicReward is None:
+        return
+    env = DummyEnv()
+    icm = ICMIntrinsicReward(obs_dim=4, action_dim=3, device="cpu")
+    env.last_action = 0
+    r1 = icm.compute(np.zeros(4, dtype=np.float32), env)
+    assert r1 == 0.0
+    env.last_action = 1
+    r2 = icm.compute(np.ones(4, dtype=np.float32), env)
+    assert isinstance(r2, float)
+    assert icm.predicted_action is not None
+

--- a/utils/icm.py
+++ b/utils/icm.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from .intrinsic import BaseIntrinsicReward
+
+
+class ICMIntrinsicReward(BaseIntrinsicReward):
+    """Intrinsic Curiosity Module computing prediction error."""
+
+    def __init__(self, obs_dim: int = 384, action_dim: int = 7, hidden_dim: int = 256, device: str = "cpu"):
+        self.obs_dim = obs_dim
+        self.action_dim = action_dim
+        self.device = device
+        self.forward_model = nn.Sequential(
+            nn.Linear(obs_dim + action_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, obs_dim),
+        ).to(device)
+        self.inverse_model = nn.Sequential(
+            nn.Linear(obs_dim * 2, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, action_dim),
+        ).to(device)
+        self.reset()
+
+    def reset(self) -> None:
+        self.prev_obs: np.ndarray | None = None
+        self.predicted_action: int | None = None
+
+    def compute_pair(self, prev_obs: np.ndarray, obs: np.ndarray, action: int) -> float:
+        o1 = torch.as_tensor(prev_obs, dtype=torch.float32, device=self.device)
+        o2 = torch.as_tensor(obs, dtype=torch.float32, device=self.device)
+        a = torch.tensor(action, dtype=torch.long, device=self.device)
+        a_one = F.one_hot(a, num_classes=self.action_dim).float()
+        pred_obs = self.forward_model(torch.cat([o1, a_one], dim=0))
+        forward_err = F.mse_loss(pred_obs, o2, reduction="mean")
+        logits = self.inverse_model(torch.cat([o1, o2], dim=0))
+        self.predicted_action = int(torch.argmax(logits).item())
+        return forward_err.item()
+
+    def compute(self, observation: np.ndarray, env) -> float:
+        action = getattr(env, "last_action", None)
+        if self.prev_obs is None or action is None:
+            self.prev_obs = np.asarray(observation)
+            return 0.0
+        reward = self.compute_pair(self.prev_obs, observation, int(action))
+        self.prev_obs = np.asarray(observation)
+        return reward
+

--- a/utils/intrinsic_client.py
+++ b/utils/intrinsic_client.py
@@ -17,8 +17,11 @@ class IntrinsicClient:
     def __exit__(self, exc_type, exc, tb) -> None:
         self.close()
 
-    def compute(self, obs: np.ndarray) -> float:
-        self.sock.sendto(obs.astype(np.float32).tobytes(), self.addr)
+    def compute(self, obs: np.ndarray, action: int | None = None) -> float:
+        arr = obs.astype(np.float32)
+        if action is not None:
+            arr = np.concatenate((np.array([action], dtype=np.float32), arr))
+        self.sock.sendto(arr.tobytes(), self.addr)
         data, _ = self.sock.recvfrom(64)
         return float(data.decode().strip())
 

--- a/utils/intrinsic_registry.py
+++ b/utils/intrinsic_registry.py
@@ -1,6 +1,7 @@
 from typing import Dict, Type, List
 
 from .intrinsic import BaseIntrinsicReward, E3BIntrinsicReward
+from .icm import ICMIntrinsicReward
 
 # Registry mapping names to intrinsic reward classes
 INTRINSIC_REWARDS: Dict[str, Type[BaseIntrinsicReward]] = {}
@@ -50,6 +51,7 @@ class CompositeIntrinsicReward(BaseIntrinsicReward):
 # Built-in registrations
 register_intrinsic("E3BIntrinsicReward", E3BIntrinsicReward)
 register_intrinsic("CompositeIntrinsicReward", CompositeIntrinsicReward)
+register_intrinsic("ICMIntrinsicReward", ICMIntrinsicReward)
 
 # Optionally register example curiosity modules
 try:


### PR DESCRIPTION
## Summary
- implement `ICMIntrinsicReward` for curiosity based on prediction error
- register the new reward plugin
- add `ICMServer` for UDP access
- extend `IntrinsicClient` and `SocketAppEnv` to send actions for intrinsic servers
- track last action in the environment
- basic unit test for the ICM reward

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_686f66f4d594832a873ba06bfacc052e