### PR TITLE
Switch servers to NATS communication

### DIFF
--- a/config.py
+++ b/config.py
@@ -51,6 +51,8 @@ class EnvConfig:
     enable_logging: bool = True
     use_world_model: bool = True
     use_intrinsic_server: bool = False
+    use_nats: bool = False
+    nats_url: str = "nats://127.0.0.1:4222"
     world_model: WorldModelConfig = field(default_factory=WorldModelConfig)
     intrinsic_server: IntrinsicServerConfig = field(default_factory=IntrinsicServerConfig)
     intrinsic_names: list[str] = field(default_factory=lambda: ["E3BIntrinsicReward"])

--- a/servers/__init__.py
+++ b/servers/__init__.py
@@ -1,8 +1,22 @@
 """Server utilities and reward tracker registry."""
 
 from .base import UdpServer
-from .reward_server import ExternalRewardTracker
-from .intrinsic_server import IntrinsicServer, start_udp_intrinsic_server
+from .nats_base import NatsServer
+from .reward_server import (
+    ExternalRewardTracker,
+    start_nats_reward_server,
+)
+from .intrinsic_server import (
+    IntrinsicServer,
+    start_udp_intrinsic_server,
+    start_nats_intrinsic_server,
+)
+from .action_server import (
+    ActionRewardServer,
+    start_combined_udp_server,
+    start_nats_combined_server,
+)
+from .world_model_server import start_nats_world_model_server
 
 try:
     from examples.constant_tracker import ConstantRewardTracker
@@ -16,9 +30,16 @@ if ConstantRewardTracker is not None:
 
 __all__ = [
     "UdpServer",
+    "NatsServer",
     "REWARD_TRACKERS",
     "ExternalRewardTracker",
     "IntrinsicServer",
     "start_udp_intrinsic_server",
+    "start_nats_intrinsic_server",
+    "start_nats_reward_server",
+    "ActionRewardServer",
+    "start_combined_udp_server",
+    "start_nats_combined_server",
+    "start_nats_world_model_server",
 ]
 

--- a/servers/nats_base.py
+++ b/servers/nats_base.py
@@ -1,0 +1,46 @@
+import asyncio
+from typing import Optional, Callable
+from nats.aio.client import Client as NATS
+
+
+class NatsServer:
+    """Simple NATS request/reply server."""
+
+    def __init__(self, subject: str, url: str = "nats://127.0.0.1:4222"):
+        self.subject = subject
+        self.url = url
+        self.loop = asyncio.new_event_loop()
+        self.nc = NATS()
+        self._shutdown = asyncio.Event()
+        print(f"[NatsServer] Listening on {subject} at {url}")
+
+    async def handle(self, data: bytes) -> Optional[bytes]:
+        """Handle one request and return an optional reply."""
+        raise NotImplementedError
+
+    async def _cb(self, msg):
+        reply = await self.handle(msg.data)
+        if isinstance(reply, str):
+            reply = reply.encode()
+        if reply is not None and msg.reply:
+            await self.nc.publish(msg.reply, reply)
+
+    async def _serve(self, cleanup: Optional[Callable[[], None]] = None):
+        await self.nc.connect(self.url, loop=self.loop)
+        await self.nc.subscribe(self.subject, cb=self._cb)
+        await self._shutdown.wait()
+        await self.nc.drain()
+        if cleanup:
+            cleanup()
+
+    def serve(self, cleanup: Optional[Callable[[], None]] = None) -> None:
+        try:
+            self.loop.run_until_complete(self._serve(cleanup))
+        except KeyboardInterrupt:
+            pass
+        finally:
+            if not self.loop.is_closed():
+                self.loop.close()
+
+    def shutdown(self) -> None:
+        self.loop.call_soon_threadsafe(self._shutdown.set)

--- a/utils/nats_client.py
+++ b/utils/nats_client.py
@@ -1,0 +1,75 @@
+import asyncio
+import numpy as np
+from nats.aio.client import Client as NATS
+
+
+class NatsClient:
+    """Simple synchronous wrapper around a NATS client."""
+
+    def __init__(self, url: str = "nats://127.0.0.1:4222", timeout: float = 0.5):
+        self.url = url
+        self.timeout = timeout
+        self.nc = NATS()
+        self.loop = asyncio.new_event_loop()
+        self.connected = False
+
+    def _connect(self) -> None:
+        if not self.connected:
+            self.loop.run_until_complete(self.nc.connect(self.url, loop=self.loop))
+            self.connected = True
+
+    def request(self, subject: str, data: bytes = b"") -> bytes:
+        self._connect()
+        msg = self.loop.run_until_complete(
+            self.nc.request(subject, data, timeout=self.timeout)
+        )
+        return msg.data
+
+    def close(self) -> None:
+        if self.connected:
+            self.loop.run_until_complete(self.nc.drain())
+            self.loop.close()
+            self.connected = False
+
+
+class NatsActionClient(NatsClient):
+    """Client for actions and rewards over NATS."""
+
+    def send_action(self, action_idx: int) -> None:
+        self.request("actions", str(action_idx).encode())
+
+    def get_reward(self) -> float:
+        data = self.request("actions", b"GET")
+        try:
+            return float(data.decode())
+        except Exception:
+            return 0.0
+
+    def send_reset(self) -> None:
+        self.request("actions", b"RESET")
+
+
+class NatsWorldModelClient(NatsClient):
+    """Client for world model predictions over NATS."""
+
+    def predict(self, obs_sequence):
+        data = obs_sequence.astype("float32").tobytes()
+        reply = self.request("world_model", data)
+        return np.frombuffer(reply, dtype=np.float32)
+
+
+class NatsIntrinsicClient(NatsClient):
+    """Client for intrinsic reward over NATS."""
+
+    def compute(self, obs, action=None) -> float:
+        arr = obs.astype("float32")
+        if action is not None:
+            arr = np.concatenate((np.array([action], dtype=np.float32), arr))
+        data = self.request("intrinsic", arr.tobytes())
+        try:
+            return float(data.decode())
+        except Exception:
+            return 0.0
+
+    def send_reset(self) -> None:
+        self.request("intrinsic", b"RESET")


### PR DESCRIPTION
## Summary
- add NatsServer base implementation
- support NATS communication for reward, action, world-model and intrinsic servers
- extend environment and config with NATS options
- provide client wrappers for NATS
- handle headless import of `pynput`
- update tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b0cf2f4e8832a8e59f456e729abe1