### PR TITLE
Implement NATS intrinsic orchestrator server

### DIFF
--- a/intrinsic_servers/e3m_server.py
+++ b/intrinsic_servers/e3m_server.py
@@ -1,20 +1,31 @@
 from __future__ import annotations
-import numpy as np
-from utils.intrinsic import E3BIntrinsicReward
-from .base import BaseUDPIntrinsicServer, IntrinsicInput
-from .registry import register
+
+from servers.intrinsic_server import IntrinsicServer
 
 
-@register("e3b")
-class E3MServer(BaseUDPIntrinsicServer):
-    """Intrinsic server wrapping :class:`E3BIntrinsicReward`."""
+class E3BNatsServer(IntrinsicServer):
+    """Convenience NATS server for ``E3BIntrinsicReward``."""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 5008, *, latent_dim: int = 384, device: str = "cpu"):
-        self.module = E3BIntrinsicReward(latent_dim=latent_dim, device=device)
-        super().__init__(host, port, latent_dim=latent_dim, device=device)
+    def __init__(self, subject: str = "intrinsic", *, latent_dim: int = 384,
+                 device: str = "cpu", url: str = "nats://127.0.0.1:4222"):
+        super().__init__("E3BIntrinsicReward", subject=subject,
+                         latent_dim=latent_dim, device=device, url=url)
 
-    def reset(self) -> None:
-        self.module.reset()
 
-    def compute(self, inp: IntrinsicInput) -> float:
-        return float(self.module.compute(np.asarray(inp.observation), None))
+def start_e3b_server(subject: str = "intrinsic", *, latent_dim: int = 384,
+                     device: str = "cpu", url: str = "nats://127.0.0.1:4222") -> None:
+    server = E3BNatsServer(subject=subject, latent_dim=latent_dim,
+                           device=device, url=url)
+    server.serve()
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Start the E3B intrinsic reward server")
+    parser.add_argument("--subject", default="intrinsic", help="NATS subject")
+    parser.add_argument("--url", default="nats://127.0.0.1:4222", help="NATS server URL")
+    parser.add_argument("--latent-dim", type=int, default=384, help="Embedding dimension")
+    parser.add_argument("--device", default="cpu", help="Torch device")
+    args = parser.parse_args()
+    start_e3b_server(subject=args.subject, latent_dim=args.latent_dim,
+                     device=args.device, url=args.url)

--- a/intrinsic_servers/icm_server.py
+++ b/intrinsic_servers/icm_server.py
@@ -1,50 +1,35 @@
 from __future__ import annotations
-import numpy as np
-from utils.icm import ICMIntrinsicReward
-from .base import BaseUDPIntrinsicServer, IntrinsicInput
-from .registry import register
+
+from servers.intrinsic_server import IntrinsicServer
 
 
-@register("icm")
-class ICMServer(BaseUDPIntrinsicServer):
-    """UDP server providing ICM intrinsic rewards."""
+class ICMNatsServer(IntrinsicServer):
+    """Convenience NATS server for ``ICMIntrinsicReward``."""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 5009, *, latent_dim: int = 384, action_dim: int = 7, device: str = "cpu"):
-        self.module = ICMIntrinsicReward(obs_dim=latent_dim, action_dim=action_dim, device=device)
+    def __init__(self, subject: str = "intrinsic", *, latent_dim: int = 384,
+                 action_dim: int = 7, device: str = "cpu", url: str = "nats://127.0.0.1:4222"):
+        name = "ICMIntrinsicReward"
+        super().__init__(name, subject=subject, latent_dim=latent_dim,
+                         device=device, url=url)
         self.action_dim = action_dim
-        self._prev_obs: np.ndarray | None = None
-        self._prev_action: int | None = None
-        super().__init__(host, port, latent_dim=latent_dim, device=device)
 
-    def reset(self) -> None:
-        self.module.reset()
-        self._prev_obs = None
-        self._prev_action = None
 
-    def handle(self, data: bytes, addr):
-        if data == b"RESET":
-            self.reset()
-            return b"OK"
-        if data == b"PING":
-            return b"PONG"
-        arr = np.frombuffer(data, dtype=np.float32)
-        if arr.size != self.latent_dim + 1:
-            return b"ERR"
-        action = int(arr[0])
-        obs = arr[1:]
-        inp = IntrinsicInput(observation=obs, action=action)
-        val = float(self.compute(inp))
-        return f"{val:.6f}"
+def start_icm_server(subject: str = "intrinsic", *, latent_dim: int = 384,
+                     action_dim: int = 7, device: str = "cpu",
+                     url: str = "nats://127.0.0.1:4222") -> None:
+    server = ICMNatsServer(subject=subject, latent_dim=latent_dim,
+                           action_dim=action_dim, device=device, url=url)
+    server.serve()
 
-    def compute(self, inp: IntrinsicInput) -> float:
-        obs = np.asarray(inp.observation)
-        action = int(inp.action if inp.action is not None else 0)
-        if self._prev_obs is None:
-            self._prev_obs = obs
-            self._prev_action = action
-            return 0.0
-        reward = self.module.compute_pair(self._prev_obs, obs, action)
-        self._prev_obs = obs
-        self._prev_action = action
-        return float(reward)
 
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Start the ICM intrinsic reward server")
+    parser.add_argument("--subject", default="intrinsic", help="NATS subject")
+    parser.add_argument("--url", default="nats://127.0.0.1:4222", help="NATS server URL")
+    parser.add_argument("--latent-dim", type=int, default=384, help="Embedding dimension")
+    parser.add_argument("--action-dim", type=int, default=7, help="Action dimension")
+    parser.add_argument("--device", default="cpu", help="Torch device")
+    args = parser.parse_args()
+    start_icm_server(subject=args.subject, latent_dim=args.latent_dim,
+                     action_dim=args.action_dim, device=args.device, url=args.url)

--- a/intrinsic_servers/orchestrator.py
+++ b/intrinsic_servers/orchestrator.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 from typing import Iterable, Tuple
 
-from .base import BaseUDPIntrinsicServer, IntrinsicInput
+from utils.intrinsic import BaseIntrinsicReward
 
 
 class IntrinsicRewardOrchestrator:
-    """Combine multiple intrinsic servers with optional weights."""
+    """Combine multiple intrinsic reward modules with optional weights."""
 
-    def __init__(self, modules: Iterable[Tuple[BaseUDPIntrinsicServer, float]]):
+    def __init__(self, modules: Iterable[Tuple[BaseIntrinsicReward, float]]):
         self.modules = list(modules)
 
-    def compute_all(self, inp: IntrinsicInput) -> float:
+    def compute_all(self, observation, env=None) -> float:
         total = 0.0
         for module, weight in self.modules:
-            total += module.compute(inp) * weight
+            total += module.compute(observation, env) * weight
         return float(total)
+
+    def reset(self) -> None:
+        for module, _ in self.modules:
+            if hasattr(module, "reset"):
+                module.reset()

--- a/intrinsic_servers/orchestrator_server.py
+++ b/intrinsic_servers/orchestrator_server.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+import importlib
+import asyncio
+from typing import Optional, Callable, Sequence
+from nats.aio.client import Client as NATS
+import numpy as np
+from utils.intrinsic_registry import get_reward
+from utils.intrinsic import BaseIntrinsicReward
+
+
+class NatsServer:
+    """Simple NATS request/reply server."""
+
+    def __init__(self, subject: str, url: str = "nats://127.0.0.1:4222"):
+        self.subject = subject
+        self.url = url
+        self.loop = asyncio.new_event_loop()
+        self.nc = NATS()
+        self._shutdown = asyncio.Event()
+        print(f"[NatsServer] Listening on {subject} at {url}")
+
+    async def handle(self, data: bytes) -> Optional[bytes]:
+        raise NotImplementedError
+
+    async def _cb(self, msg):
+        reply = await self.handle(msg.data)
+        if isinstance(reply, str):
+            reply = reply.encode()
+        if reply is not None and msg.reply:
+            await self.nc.publish(msg.reply, reply)
+
+    async def _serve(self, cleanup: Optional[Callable[[], None]] = None):
+        await self.nc.connect(servers=[self.url])
+        await self.nc.subscribe(self.subject, cb=self._cb)
+        await self._shutdown.wait()
+        await self.nc.drain()
+        if cleanup:
+            cleanup()
+
+    def serve(self, cleanup: Optional[Callable[[], None]] = None) -> None:
+        try:
+            self.loop.run_until_complete(self._serve(cleanup))
+        except KeyboardInterrupt:
+            pass
+        finally:
+            if not self.loop.is_closed():
+                self.loop.close()
+
+    def shutdown(self) -> None:
+        self.loop.call_soon_threadsafe(self._shutdown.set)
+
+
+class NatsIntrinsicOrchestrator(NatsServer):
+    """NATS server combining multiple intrinsic rewards."""
+
+    def __init__(self, reward_names: Sequence[str], subject: str = "intrinsic", *,
+                 latent_dim: int = 384, device: str = "cpu",
+                 url: str = "nats://127.0.0.1:4222"):
+        super().__init__(subject, url)
+        self.modules: list[BaseIntrinsicReward] = []
+        for name in reward_names:
+            cls = None
+            try:
+                cls = get_reward(name)
+            except KeyError:
+                if "." in name:
+                    mod_name, cls_name = name.rsplit(".", 1)
+                    module = importlib.import_module(mod_name)
+                    cls = getattr(module, cls_name)
+                else:
+                    raise
+            try:
+                inst = cls(latent_dim=latent_dim, device=device)
+            except TypeError:
+                inst = cls()
+            self.modules.append(inst)
+
+    async def handle(self, data: bytes) -> bytes | None:
+        if data == b"RESET":
+            for m in self.modules:
+                if hasattr(m, "reset"):
+                    m.reset()
+            return b"OK"
+        arr = np.frombuffer(data, dtype=np.float32)
+        total = 0.0
+        for m in self.modules:
+            total += float(m.compute(arr, None))
+        return f"{total:.6f}".encode()
+
+
+NatsIntrinsicOrchestratorServer = NatsIntrinsicOrchestrator
+
+
+def start_nats_orchestrator_server(reward_names: Sequence[str], subject: str = "intrinsic", *,
+                                   latent_dim: int = 384, device: str = "cpu",
+                                   url: str = "nats://127.0.0.1:4222") -> None:
+    server = NatsIntrinsicOrchestratorServer(
+        reward_names,
+        subject=subject,
+        latent_dim=latent_dim,
+        device=device,
+        url=url,
+    )
+    server.serve()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Start the NATS intrinsic orchestrator server")
+    parser.add_argument("names", nargs="+", help="Intrinsic reward class names or module paths")
+    parser.add_argument("--subject", default="intrinsic", help="NATS subject")
+    parser.add_argument("--url", default="nats://127.0.0.1:4222", help="NATS server URL")
+    parser.add_argument("--latent-dim", type=int, default=384, help="Embedding dimension")
+    parser.add_argument("--device", default="cpu", help="Torch device")
+    args = parser.parse_args()
+
+    start_nats_orchestrator_server(
+        args.names,
+        subject=args.subject,
+        latent_dim=args.latent_dim,
+        device=args.device,
+        url=args.url,
+    )

--- a/tests/test_intrinsic_orchestrator_server.py
+++ b/tests/test_intrinsic_orchestrator_server.py
@@ -1,0 +1,39 @@
+import subprocess
+import time
+import threading
+import numpy as np
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+import sys
+sys.path.insert(0, str(ROOT))
+
+from intrinsic_servers.orchestrator_server import NatsIntrinsicOrchestratorServer
+from utils.nats_client import NatsIntrinsicClient
+from tests.utils import get_free_port
+
+
+def test_orchestrator_server_combines_rewards():
+    port = get_free_port()
+    url = f"nats://127.0.0.1:{port}"
+    proc = subprocess.Popen(["nats-server", "-p", str(port)], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    time.sleep(0.2)
+    server = NatsIntrinsicOrchestratorServer([
+        'examples.custom_curiosity.ConstantCuriosity',
+        'examples.custom_curiosity.ConstantCuriosity',
+    ], subject='intrinsic', latent_dim=4, device='cpu', url=url)
+    t = threading.Thread(target=server.serve, daemon=True)
+    t.start()
+
+    client = NatsIntrinsicClient(url)
+    try:
+        arr = np.zeros(4, dtype=np.float32)
+        val = client.compute(arr)
+        assert val == 2.0
+        client.send_reset()
+    finally:
+        client.close()
+        server.shutdown()
+        t.join(timeout=1)
+        proc.terminate()
+        proc.wait(timeout=5)


### PR DESCRIPTION
## Summary
- add `NatsIntrinsicOrchestratorServer` to combine multiple intrinsic rewards
- rewrite `orchestrator.py` for local intrinsic modules
- update E3B and ICM server wrappers for NATS
- test orchestrator server

## Testing
- `pytest -q tests/test_intrinsic_orchestrator_server.py`
- `pytest -q` *(fails: `tests/test_nats_world_clients.py`, `tests/test_world_model_server.py`)*

------
https://chatgpt.com/codex/tasks/task_e_687b39aa98a0832a8be113918e57bc30