### PR TITLE
Fix missing env type

### DIFF
--- a/config.py
+++ b/config.py
@@ -36,7 +36,7 @@ class IntrinsicServerConfig:
 
 @dataclass
 class EnvConfig:
-    """Default parameters for ``SocketAppEnv``."""
+    """Default parameters for ``NatsAppEnv``."""
     max_steps: int = int(1e10)
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
     action_dim: int = 7

--- a/train.py
+++ b/train.py
@@ -87,7 +87,7 @@ def run_sb3_training(cfg: Config, timesteps: int = 5000, manager: Optional[Serve
 
 def train_loop(
     cfg: Config,
-    env: SocketAppEnv,
+    env: NatsAppEnv,
     actor: Actor,
     critic: Q_Critic,
     optim_actor: optim.Optimizer,


### PR DESCRIPTION
## Summary
- fix type hints for training to use `NatsAppEnv`
- update config documentation

## Testing
- `pytest -q` *(fails: NoRespondersError; NameError: threading not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687b40e04810832ab2c6599eb64824c9